### PR TITLE
fix(sync content): add protection - ask user is he sure he want to remove his content

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -130,7 +130,6 @@ export const sync = async (props: CLIOptions) => {
                             process.exit(0);
                         } else {
                             if (deletionConfirmation) {
-                                console.log(deletionConfirmation.trim());
                                 Logger.warning(
                                     "Deleting all stories in your space and then applying test ones..."
                                 );

--- a/src/utils/others.ts
+++ b/src/utils/others.ts
@@ -1,2 +1,42 @@
+import readline from "node:readline/promises";
+import chalk from "chalk";
+
 export const generateDatestamp = (datestamp: Date) =>
     `${datestamp.getUTCFullYear()}-${datestamp.getUTCMonth()}-${datestamp.getUTCDay()}_${datestamp.getUTCHours()}-${datestamp.getUTCMinutes()}-${datestamp.getUTCSeconds()}`;
+
+export const askForConfirmation = async (
+    message: string,
+    resolveYes: () => void,
+    resolveNo: () => void
+) => {
+    // This section has to be changed, it was fast solution to asking for confirmation
+    // need to reimplement it better
+    await new Promise((resolve) => {
+        setTimeout(() => {
+            console.log(" ");
+            console.log(" ");
+            resolve(true);
+        }, 3000);
+    });
+
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+        prompt: chalk.red(`${message} (y/n) > `),
+    });
+
+    rl.prompt();
+    for await (const deletionConfirmation of rl) {
+        if (deletionConfirmation.trim() !== "y") {
+            resolveNo();
+            process.exit(0);
+        } else {
+            if (deletionConfirmation) {
+                resolveYes();
+
+                break;
+            }
+        }
+        rl.prompt();
+    }
+};


### PR DESCRIPTION
Probably this should be extracted to a function and used in a bunch of places (for example `--ssot` flag for syncing components as a **single source of truth**)