### PR TITLE
fix(migrate): make the scoped preset run reachable from the built CLI (GCTT-3851)

### DIFF
--- a/__tests__/cli/migrate-presets.test.ts
+++ b/__tests__/cli/migrate-presets.test.ts
@@ -46,10 +46,20 @@ vi.mock("../../src/utils/logger.js", () => ({
 
 import { migrate } from "../../src/cli/commands/migrate.js";
 
+/**
+ * meow declares --migrate-from with `default: "space", isRequired: true`, so
+ * `migrateFrom` is present in `flags` on every real invocation. Tests that
+ * omit it do not exercise the routing the CLI actually performs.
+ */
+const cliFlags = (overrides: Record<string, unknown>) => ({
+    migrateFrom: "space",
+    ...overrides,
+});
+
 const runMigratePresets = (flags: Record<string, unknown>) =>
     migrate({
         input: ["migrate", "presets"],
-        flags,
+        flags: cliFlags(flags),
     } as any);
 
 beforeEach(() => {
@@ -117,7 +127,7 @@ describe("migrate presets <component...> (scoped run)", () => {
     const runScoped = (components: string[], flags: Record<string, unknown>) =>
         migrate({
             input: ["migrate", "presets", ...components],
-            flags,
+            flags: cliFlags(flags),
         } as any);
 
     it("scopes the migration to the provided component names", async () => {
@@ -162,7 +172,28 @@ describe("migrate presets <component...> (scoped run)", () => {
         ]);
     });
 
-    it("falls back to the migration's own component scope when none is named", async () => {
+    it("routes on the typed command, not on the presence of the migrateFrom default", async () => {
+        // Regression: --migrate-from is declared with `default: "space"` and
+        // `isRequired: true`, so `migrateFrom` is in `flags` on every real
+        // invocation. Routing this branch through `isIt("empty")` made the
+        // scoped run unreachable from the built CLI.
+        await runScoped(["text-block"], {
+            migrateFrom: "space",
+            from: "12345",
+            to: "12345",
+            migration: "migration-a",
+            dryRun: true,
+        });
+
+        expect(
+            mocks.migrateProvidedComponentsDataInStories,
+        ).toHaveBeenCalledTimes(1);
+        const [engineArgs] =
+            mocks.migrateProvidedComponentsDataInStories.mock.calls[0];
+        expect(engineArgs.componentsToMigrate).toEqual(["text-block"]);
+    });
+
+    it("reports a wrong flag combination when neither --all nor components are given", async () => {
         await runScoped([], {
             from: "12345",
             to: "12345",
@@ -170,9 +201,10 @@ describe("migrate presets <component...> (scoped run)", () => {
             dryRun: true,
         });
 
-        const [engineArgs] =
-            mocks.migrateProvidedComponentsDataInStories.mock.calls[0];
-        expect(engineArgs.componentsToMigrate).toEqual([]);
+        expect(
+            mocks.migrateProvidedComponentsDataInStories,
+        ).not.toHaveBeenCalled();
+        expect(mocks.migrateAllComponentsDataInStories).not.toHaveBeenCalled();
     });
 
     it("still routes --all through the all-components path", async () => {
@@ -269,12 +301,12 @@ describe("migrate presets cross-space guard", () => {
         await expect(
             migrate({
                 input: ["migrate", "presets", "text-block"],
-                flags: {
+                flags: cliFlags({
                     from: "12345",
                     to: "67890",
                     migration: "migration-a",
                     yes: true,
-                },
+                }),
             } as any),
         ).rejects.toThrow("the same Storyblok space");
 

--- a/docs/migrate-continue.md
+++ b/docs/migrate-continue.md
@@ -249,7 +249,11 @@ confirmation output as the rollback source. No new backup step is added.
   require `--manifest <filename>`; never auto-pick newest.
 - **D-2 (confirmation):** always confirm before writing; `--yes` only bypasses the prompt
   (CI parity), never changes what is shown/logged.
-- **D-3 (presets):** v1 is stories only; presets deferred.
+- **D-3 (presets):** v1 was stories only; presets deferred. Superseded by DT-319 — the preset
+  dry-run → continue path is now covered by tests (`__tests__/api/preset-data-migration.test.ts`).
+  A preset dry-run writes a `preset-continue-manifest`, `prepareContinueMigration` reconstructs
+  it, and `finalizeMigration` replays the write through `presets.updatePresets`. Preset manifests
+  always record `save-only` with no publication languages, since presets cannot be published.
 - **D-4 (dirty records, F3):** dry-run serializes the exact `dirtyPublishedRecords` to a new
   machine artifact; `continue` references and loads it as-is. (Chosen over reconstructing from
   the human summary, which is fragile.)

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -427,8 +427,14 @@ export const migrate = async (props: CLIOptions) => {
 
             console.log("Migrating with presets");
 
-            if (isIt("empty")) {
-                const componentsToMigrate = unpackElements(input) || [""];
+            const presetComponentsToMigrate = unpackElements(input);
+
+            // Not `isIt("empty")`: --migrate-from is declared with a default,
+            // so meow always puts `migrateFrom` in flags, which makes the
+            // `empty` rule impossible to match. Route on what was actually
+            // typed instead.
+            if (!flags["all"] && presetComponentsToMigrate.length > 0) {
+                const componentsToMigrate = presetComponentsToMigrate;
 
                 const migrateFrom: MigrateFrom = "space";
 


### PR DESCRIPTION
> **Superseded by #394.** That PR fixes the shared root cause (`rules.empty` not consuming meow's always-present `migrateFrom`), which restores **both** `migrate presets <component...>` and `migrate content <component...>` in one line, with no preset-specific routing. Recommend closing this unmerged and re-landing the `docs/migrate-continue.md` note separately. Left open for you to decide.

Follow-up to #392, which merged and released as **v6.5.0-beta.2** before these two commits were pushed. The scoped preset run that #392 advertised does not work in that release.

## The bug

`sb-mig migrate presets text-block --migration x` — the headline feature of GCTT-3838 — prints `Wrong combination of flags. check help for more info.` and exits without doing anything.

Reproduced against the released build:

```
$ git checkout origin/beta && npm run build
$ node dist/cli/index.js migrate presets text-block --from 12345 --to 12345 --migration nope --dry-run
✘ Wrong combination of flags. check help for more info.

# with this PR
! Preparing to migrate...
Error: Migration config 'nope' probably doesnt exist. Create one    ← reaches the engine, as intended
```

## Why

`--migrate-from` is declared with `default: "space", isRequired: true` (`src/cli/index.ts:67`), so meow puts `migrateFrom` into `flags` on **every** invocation. `isItFactory` returns true only when every present flag key is either whitelisted or consumed by the rule — and for the `empty` rule, `migrateFrom` is neither:

```js
const rules = { empty: [], all: ["all", "migrateFrom"] }
// whitelist has from/to/migration/dryRun/... but NOT migrateFrom
isIt("empty")  // → always false, for any invocation
```

So the branch #392 added was unreachable. This is the same trap already documented for `migrate content <component...>` in the docs site ("Help lists this form, but the current built CLI rejects it").

**It passed CI because the CLI test hand-built a flags object without `migrateFrom`** — a fixture that doesn't match what meow produces. The assertions were correct; the input was fiction. That is the actual root cause, and it's the part worth fixing properly.

## The fix

- The presets branch routes on what was actually typed — `!flags["all"] && presetComponentsToMigrate.length > 0` — instead of `isIt("empty")`. The stories matcher is untouched.
- The CLI test helper now injects `migrateFrom: "space"` the way meow does, so every test in that file exercises real routing. Added a named regression test that pins this specific failure.
- Replaced the test that asserted behaviour only reachable through the dead path (scoped run with zero component names) with one asserting the real outcome: no components and no `--all` is a wrong-flag-combination.

Verified against the **built** CLI this time, not just the unit harness — scoped, `--all`, and both cross-space guard paths.

Also included: `docs/migrate-continue.md` D-3 ("presets deferred") marked superseded, which was part of the same push.

## Not fixed here

`migrate content <component...>` has the identical defect. It's pre-existing, already has a documented `--all --migrationComponents` workaround, and fixing it changes stories routing — worth its own ticket rather than smuggling it into a follow-up.

## Checks

`npm run test:unit` → 57 files / 584 tests. `npm run build` clean. Branched directly off current `beta` (`28d00d6`).

Docs for the preset work are in sb-mig-landing#11; they describe the scoped run as working, so that PR should merge alongside this one rather than the already-merged #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)