### PR TITLE
feat(copy): classify story references by scope (MAR-2670)

### DIFF
--- a/__tests__/api/copy-manifest.test.ts
+++ b/__tests__/api/copy-manifest.test.ts
@@ -220,11 +220,11 @@ describe("copy graph model", () => {
             sourceStoryId: 100,
             referencedStoryId: 101,
             path: "content.related[0]",
-            status: "preserved_external",
+            status: "will_break",
         });
         graph.warnings.push({
-            code: "external_story_reference",
-            message: "External story reference preserved.",
+            code: "broken_story_reference",
+            message: "Story reference points outside this copy.",
         });
 
         expect(graph).toMatchObject({

--- a/__tests__/api/copy-reference-classifier.test.ts
+++ b/__tests__/api/copy-reference-classifier.test.ts
@@ -195,17 +195,6 @@ describe("copy reference classifier", () => {
             expect(classified.status).toBe("will_relink");
         });
 
-        it("does classify alternates as ordinary content references", () => {
-            const [classified] = classify([
-                reference({
-                    path: "alternates[0].parent_id",
-                    referencedStoryId: 999,
-                }),
-            ]);
-
-            expect(classified.status).toBe("will_break");
-        });
-
         it("leaves scanner-decided statuses untouched", () => {
             const classified = classify([
                 reference({

--- a/__tests__/api/copy-reference-classifier.test.ts
+++ b/__tests__/api/copy-reference-classifier.test.ts
@@ -1,0 +1,330 @@
+import type {
+    CopyGraphStoryNode,
+    CopyGraphStoryReference,
+    CopyMaps,
+} from "../../src/api/copy/types.js";
+
+import { describe, expect, it } from "vitest";
+
+import {
+    buildCopyReferenceSelection,
+    classifyStoryReferences,
+    countStoryReferenceStatuses,
+    createEmptyCopyMaps,
+    createEmptyCopyReferenceSelection,
+    describeBrokenStoryReferenceTarget,
+    groupBrokenStoryReferences,
+} from "../../src/api/copy/index.js";
+
+const storyNode = (
+    sourceId: number,
+    sourceUuid: string,
+    sourceFullSlug: string,
+): CopyGraphStoryNode => ({
+    type: "story",
+    sourceId,
+    sourceUuid,
+    sourceFullSlug,
+    action: "create",
+});
+
+const reference = (
+    overrides: Partial<CopyGraphStoryReference>,
+): CopyGraphStoryReference => ({
+    type: "story_reference",
+    sourceStoryId: 10,
+    sourceStoryUuid: "page-one-uuid",
+    sourceStoryFullSlug: "probe/pages/page-one",
+    path: "content.ref_link.id",
+    status: "unclassified",
+    ...overrides,
+});
+
+const ledgerWith = ({
+    storyIds = [] as Array<[number, number]>,
+    storyUuids = [] as Array<[string, string]>,
+}): CopyMaps => {
+    const maps = createEmptyCopyMaps();
+
+    for (const [source, target] of storyIds) {
+        maps.storyIds.set(source, target);
+    }
+
+    for (const [source, target] of storyUuids) {
+        maps.storyUuids.set(source, target);
+    }
+
+    return maps;
+};
+
+const classify = (
+    references: CopyGraphStoryReference[],
+    {
+        stories = [] as CopyGraphStoryNode[],
+        copyMaps = createEmptyCopyMaps(),
+        sameSpace = false,
+    } = {},
+) =>
+    classifyStoryReferences({
+        storyReferences: references,
+        selection: buildCopyReferenceSelection(stories),
+        copyMaps,
+        sameSpace,
+    });
+
+describe("copy reference classifier", () => {
+    describe("buildCopyReferenceSelection", () => {
+        it("collects plan story ids and uuids", () => {
+            const selection = buildCopyReferenceSelection([
+                storyNode(10, "page-one-uuid", "probe/pages/page-one"),
+                storyNode(11, "page-two-uuid", "probe/pages/page-two"),
+            ]);
+
+            expect(Array.from(selection.storyIds)).toEqual([10, 11]);
+            expect(Array.from(selection.storyUuids)).toEqual([
+                "page-one-uuid",
+                "page-two-uuid",
+            ]);
+        });
+
+        it("ignores unresolved plan items carrying sourceId 0", () => {
+            const selection = buildCopyReferenceSelection([
+                { ...storyNode(0, "", "probe/pages"), sourceUuid: undefined },
+            ]);
+
+            expect(selection.storyIds.size).toBe(0);
+            expect(selection.storyUuids.size).toBe(0);
+        });
+
+        it("creates an empty selection", () => {
+            const selection = createEmptyCopyReferenceSelection();
+
+            expect(selection.storyIds.size).toBe(0);
+            expect(selection.storyUuids.size).toBe(0);
+        });
+    });
+
+    describe("classifyStoryReferences", () => {
+        it("marks a reference into the selection will_relink by uuid", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryUuid: "shared-header-uuid" })],
+                {
+                    stories: [
+                        storyNode(
+                            20,
+                            "shared-header-uuid",
+                            "probe/shared/shared-header",
+                        ),
+                    ],
+                },
+            );
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("marks a reference into the selection will_relink by id", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryId: 20 })],
+                {
+                    stories: [
+                        storyNode(
+                            20,
+                            "shared-header-uuid",
+                            "probe/shared/shared-header",
+                        ),
+                    ],
+                },
+            );
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("marks a reference already in the ledger will_relink", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryUuid: "earlier-copy-uuid" })],
+                {
+                    copyMaps: ledgerWith({
+                        storyUuids: [["earlier-copy-uuid", "target-uuid"]],
+                    }),
+                },
+            );
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("marks an out-of-scope reference will_break in a cross-space copy", () => {
+            const [classified] = classify([
+                reference({ referencedStoryUuid: "playground-page-uuid" }),
+            ]);
+
+            expect(classified.status).toBe("will_break");
+        });
+
+        it("marks an out-of-scope reference external_kept in a same-space copy", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryUuid: "playground-page-uuid" })],
+                { sameSpace: true },
+            );
+
+            expect(classified.status).toBe("external_kept");
+        });
+
+        it("still relinks in-scope references in a same-space copy", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryUuid: "shared-header-uuid" })],
+                {
+                    sameSpace: true,
+                    stories: [
+                        storyNode(
+                            20,
+                            "shared-header-uuid",
+                            "probe/shared/shared-header",
+                        ),
+                    ],
+                },
+            );
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("never breaks parent_id, which the copy plan resolves structurally", () => {
+            const [classified] = classify([
+                reference({ path: "parent_id", referencedStoryId: 999 }),
+            ]);
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("does classify alternates as ordinary content references", () => {
+            const [classified] = classify([
+                reference({
+                    path: "alternates[0].parent_id",
+                    referencedStoryId: 999,
+                }),
+            ]);
+
+            expect(classified.status).toBe("will_break");
+        });
+
+        it("leaves scanner-decided statuses untouched", () => {
+            const classified = classify([
+                reference({
+                    referencedStoryUuid: "playground-page-uuid",
+                    status: "unresolved",
+                }),
+                reference({
+                    referencedStoryUuid: "playground-page-uuid",
+                    status: "unsupported",
+                }),
+            ]);
+
+            expect(classified.map((item) => item.status)).toEqual([
+                "unresolved",
+                "unsupported",
+            ]);
+        });
+
+        it("does not mutate the references it is given", () => {
+            const original = reference({
+                referencedStoryUuid: "playground-page-uuid",
+            });
+
+            classify([original]);
+
+            expect(original.status).toBe("unclassified");
+        });
+    });
+
+    describe("countStoryReferenceStatuses", () => {
+        it("counts every status bucket", () => {
+            const counts = countStoryReferenceStatuses([
+                reference({ status: "will_relink" }),
+                reference({ status: "will_relink" }),
+                reference({ status: "will_break" }),
+                reference({ status: "external_kept" }),
+                reference({ status: "unresolved" }),
+                reference({ status: "unsupported" }),
+                reference({ status: "unclassified" }),
+            ]);
+
+            expect(counts).toEqual({
+                willRelink: 2,
+                willBreak: 1,
+                externalKept: 1,
+                unresolved: 1,
+                unsupported: 1,
+                unclassified: 1,
+            });
+        });
+    });
+
+    describe("groupBrokenStoryReferences", () => {
+        it("groups breaks by the story that holds them", () => {
+            const groups = groupBrokenStoryReferences([
+                reference({
+                    status: "will_break",
+                    path: "content.ref_link.id",
+                    referencedStoryUuid: "outside-uuid",
+                }),
+                reference({
+                    status: "will_break",
+                    path: "content.body[0].reference",
+                    referencedStoryUuid: "outside-uuid",
+                }),
+                reference({
+                    status: "will_relink",
+                    path: "content.related",
+                }),
+                reference({
+                    status: "will_break",
+                    sourceStoryFullSlug: "probe/pages/page-four",
+                    path: "content.ref_link.id",
+                    referencedStoryId: 777,
+                }),
+            ]);
+
+            expect(
+                groups.map((group) => [
+                    group.sourceStoryFullSlug,
+                    group.references.map((item) => item.path),
+                ]),
+            ).toEqual([
+                [
+                    "probe/pages/page-one",
+                    ["content.ref_link.id", "content.body[0].reference"],
+                ],
+                ["probe/pages/page-four", ["content.ref_link.id"]],
+            ]);
+        });
+
+        it("falls back to the source story id when the slug is missing", () => {
+            const [group] = groupBrokenStoryReferences([
+                reference({
+                    status: "will_break",
+                    sourceStoryFullSlug: undefined,
+                    sourceStoryId: 42,
+                }),
+            ]);
+
+            expect(group.sourceStoryFullSlug).toBe("#42");
+        });
+    });
+
+    describe("describeBrokenStoryReferenceTarget", () => {
+        it("prefers the uuid, then the id", () => {
+            expect(
+                describeBrokenStoryReferenceTarget(
+                    reference({ referencedStoryUuid: "outside-uuid" }),
+                ),
+            ).toBe("outside-uuid");
+            expect(
+                describeBrokenStoryReferenceTarget(
+                    reference({ referencedStoryId: 777 }),
+                ),
+            ).toBe("#777");
+            expect(describeBrokenStoryReferenceTarget(reference({}))).toBe(
+                "<unknown target>",
+            );
+        });
+    });
+});

--- a/__tests__/api/copy-reference-scanner.test.ts
+++ b/__tests__/api/copy-reference-scanner.test.ts
@@ -31,6 +31,7 @@ const story = {
     uuid: "story-uuid-100",
     full_slug: "blog/post",
     parent_id: 90,
+    // Read-only API metadata: stripped before write, so never scanned.
     alternates: [{ id: 101, parent_id: 91 }],
     content: {
         component: "page",
@@ -205,16 +206,6 @@ describe("copy reference scanner", () => {
             expect.objectContaining({
                 referencedStoryId: 90,
                 path: "parent_id",
-                status: "unclassified",
-            }),
-            expect.objectContaining({
-                referencedStoryId: 101,
-                path: "alternates[0].id",
-                status: "unclassified",
-            }),
-            expect.objectContaining({
-                referencedStoryId: 91,
-                path: "alternates[0].parent_id",
                 status: "unclassified",
             }),
             expect.objectContaining({

--- a/__tests__/api/copy-reference-scanner.test.ts
+++ b/__tests__/api/copy-reference-scanner.test.ts
@@ -205,42 +205,42 @@ describe("copy reference scanner", () => {
             expect.objectContaining({
                 referencedStoryId: 90,
                 path: "parent_id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 101,
                 path: "alternates[0].id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 91,
                 path: "alternates[0].parent_id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 102,
                 path: "content.hero[0].cta.id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryUuid: "story-uuid-103",
                 path: "content.hero[0].body.content[0].content[0].attrs.uuid",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 104,
                 path: "content.hero[0].body.content[1].attrs.body[0].link.id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 105,
                 path: "content.related[0]",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 106,
                 path: "content.related[1]",
-                status: "preserved_external",
+                status: "unclassified",
             }),
         ]);
 

--- a/__tests__/cli/copy-assets-dry-run.test.ts
+++ b/__tests__/cli/copy-assets-dry-run.test.ts
@@ -453,6 +453,18 @@ describe("copy assets dry-run", () => {
                 status: "planned",
             },
         ]);
+        // An asset-only run never rewrites stories, so story references keep
+        // the scanner's neutral status and raise no break warnings.
+        expect(
+            report.graph.storyReferences.every(
+                (reference: any) => reference.status === "unclassified",
+            ),
+        ).toBe(true);
+        expect(
+            report.graph.warnings.filter(
+                (warning: any) => warning.code === "broken_story_reference",
+            ),
+        ).toEqual([]);
         expect(report.commands.apply).toBe(
             "sb-mig copy assets --from source-space --to target-space --referenced-by-stories --source blog/post --mode subtree",
         );

--- a/__tests__/cli/copy-dry-run.test.ts
+++ b/__tests__/cli/copy-dry-run.test.ts
@@ -552,7 +552,13 @@ describe("copy stories dry-run", () => {
                 assetFolders: 2,
                 assets: 1,
                 assetReferences: 1,
-                storyReferences: 4,
+                // parent_id 0 (the space root) is not a story reference: blog
+                // -> post-1, post-1 -> blog, and post-1's parent_id.
+                storyReferences: 3,
+                storyReferencesWillRelink: 3,
+                storyReferencesWillBreak: 0,
+                storyReferencesExternalKept: 0,
+                storyReferencesUnresolved: 0,
                 errors: 0,
             },
             graph: {
@@ -1531,19 +1537,21 @@ describe("copy stories dry-run", () => {
             },
         });
         const getStoryBySlug = mocks.getStoryBySlug.getMockImplementation();
-        mocks.getStoryBySlug.mockImplementation((slug: string, options: any) => {
-            if (slug === "imported/blog") {
-                return Promise.resolve({
-                    story: {
-                        id: 9999,
-                        uuid: "stale-target-blog-uuid",
-                        full_slug: "imported/blog",
-                    },
-                });
-            }
+        mocks.getStoryBySlug.mockImplementation(
+            (slug: string, options: any) => {
+                if (slug === "imported/blog") {
+                    return Promise.resolve({
+                        story: {
+                            id: 9999,
+                            uuid: "stale-target-blog-uuid",
+                            full_slug: "imported/blog",
+                        },
+                    });
+                }
 
-            return getStoryBySlug?.(slug, options);
-        });
+                return getStoryBySlug?.(slug, options);
+            },
+        );
         mocks.updateStory
             .mockResolvedValueOnce({
                 ok: false,

--- a/__tests__/cli/copy-dry-run.test.ts
+++ b/__tests__/cli/copy-dry-run.test.ts
@@ -365,6 +365,58 @@ describe("copy stories dry-run", () => {
         await rm(tempDir, { recursive: true, force: true });
     });
 
+    it("scans only planned stories in children mode, never the excluded root", async () => {
+        const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
+        const outputPath = path.join(tempDir, "plans", "copy-plan.json");
+
+        await copyCommand({
+            input: ["copy", "stories"],
+            flags: {
+                from: "source-space",
+                to: "target-space",
+                source: "blog",
+                mode: "children",
+                destination: "imported",
+                dryRun: true,
+                outputPath,
+            },
+        } as any);
+
+        const report = JSON.parse(await readFile(outputPath, "utf8"));
+
+        expect(report.items).toMatchObject([
+            {
+                type: "story",
+                sourceFullSlug: "blog/post-1",
+                targetFullSlug: "imported/post-1",
+            },
+        ]);
+        // The root folder `blog` is fetched but not copied. Its own cta -> post-1
+        // reference must not be scanned: it would inflate the relink count for
+        // a story this run never writes.
+        expect(
+            report.graph.storyReferences.map(
+                (reference: any) => reference.sourceStoryFullSlug,
+            ),
+        ).toEqual(["blog/post-1", "blog/post-1"]);
+        expect(report.graph.storyReferences).toMatchObject([
+            { path: "parent_id", status: "will_relink" },
+            {
+                path: "content.body.content[0].attrs.uuid",
+                referencedStoryUuid: "source-blog-uuid",
+                status: "will_break",
+            },
+        ]);
+        expect(report.summary).toMatchObject({
+            storyReferences: 2,
+            storyReferencesWillRelink: 1,
+            storyReferencesWillBreak: 1,
+            storyReferencesExternalKept: 0,
+        });
+
+        await rm(tempDir, { recursive: true, force: true });
+    });
+
     it("flags source components missing from the target space during story dry-run", async () => {
         const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
         const outputPath = path.join(tempDir, "plans", "copy-plan.json");

--- a/docs/copy-command-spec.md
+++ b/docs/copy-command-spec.md
@@ -338,11 +338,24 @@ Known fields to rewrite:
 | `alternates[].parent_id`                    | story id   | Replace source parent id with target parent id   |
 | `parent_id`                                 | story id   | Replace source parent id with target parent id   |
 
-If a story reference points to a story outside the selected copy scope, the command must not silently corrupt it. The copy report should classify it:
+If a story reference points to a story outside the selected copy scope, the command must not silently corrupt it. Every scanned story reference in the copy graph (`graph.storyReferences[].status`) is classified against the copy plan **and** the ledger:
 
-- `preserved_external_reference`
-- `unresolved_story_reference`
-- `skipped_reference_rewrite`
+| Status          | Meaning                                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `unclassified`  | Emitted by the scanner, which sees one story at a time and cannot know the plan. Replaced before the graph is reported. |
+| `will_relink`   | The referenced story is inside the selection (its mapping exists by phase 2) or is already in the loaded ledger.        |
+| `will_break`    | The referenced story is outside the selection and not in the ledger; in a cross-space copy this reference dangles.      |
+| `external_kept` | Same-space copy, where continuing to point at the original story is correct.                                            |
+| `unresolved`    | Reference policy `fail`: the reference cannot be handled.                                                               |
+| `unsupported`   | The reference shape is not rewritable.                                                                                  |
+
+Notes:
+
+- `parent_id` is resolved by the copy plan itself — phase 1 creates every shell under its planned parent, and the top of the selection lands under the destination — so it is always `will_relink` and never reported as a break.
+- `parent_id: 0` is Storyblok's "lives at the space root" sentinel, not a story id, and is not recorded as a reference at all.
+- When `will_break > 0` the dry-run prints a loud report naming each holding story and field path, and the graph carries a `broken_story_reference` warning per story.
+
+The dry-run summary exposes the same accounting as `storyReferencesWillRelink`, `storyReferencesWillBreak`, `storyReferencesExternalKept` and `storyReferencesUnresolved`.
 
 Potential policies:
 

--- a/src/api/copy/index.ts
+++ b/src/api/copy/index.ts
@@ -1,5 +1,6 @@
 export * from "./graph.js";
 export * from "./manifest.js";
+export * from "./reference-classifier.js";
 export * from "./reference-scanner.js";
 export * from "./reference-rewriter.js";
 export * from "./assets.js";

--- a/src/api/copy/reference-classifier.ts
+++ b/src/api/copy/reference-classifier.ts
@@ -1,0 +1,213 @@
+import type {
+    CopyGraphStoryNode,
+    CopyGraphStoryReference,
+    CopyMaps,
+    CopyStoryReferenceStatus,
+} from "./types.js";
+
+/**
+ * The set of source stories a copy run is about to write. Built from the copy
+ * plan, so a reference pointing into it is guaranteed to have a mapping by the
+ * time phase 2 rewrites content.
+ */
+export type CopyReferenceSelection = {
+    storyIds: Set<number>;
+    storyUuids: Set<string>;
+};
+
+export type CopyStoryReferenceStatusCounts = {
+    willRelink: number;
+    willBreak: number;
+    externalKept: number;
+    unresolved: number;
+    unsupported: number;
+    unclassified: number;
+};
+
+export type CopyBrokenStoryReferenceGroup = {
+    sourceStoryFullSlug: string;
+    references: CopyGraphStoryReference[];
+};
+
+/**
+ * `parent_id` is resolved by the copy plan itself: phase 1 creates every shell
+ * under its planned parent, and the top of the selection lands under the
+ * destination. It cannot dangle the way a content reference can, so it is
+ * never reported as a break — even when the source parent is out of scope.
+ */
+const STRUCTURAL_REFERENCE_PATHS = new Set(["parent_id"]);
+
+export const buildCopyReferenceSelection = (
+    stories: CopyGraphStoryNode[],
+): CopyReferenceSelection => {
+    const storyIds = new Set<number>();
+    const storyUuids = new Set<string>();
+
+    for (const story of stories) {
+        // Plan items whose source story could not be resolved carry sourceId 0.
+        if (Number.isFinite(story.sourceId) && story.sourceId > 0) {
+            storyIds.add(story.sourceId);
+        }
+
+        if (story.sourceUuid) {
+            storyUuids.add(story.sourceUuid);
+        }
+    }
+
+    return { storyIds, storyUuids };
+};
+
+export const createEmptyCopyReferenceSelection =
+    (): CopyReferenceSelection => ({
+        storyIds: new Set(),
+        storyUuids: new Set(),
+    });
+
+const isInSelection = (
+    reference: CopyGraphStoryReference,
+    selection: CopyReferenceSelection,
+): boolean =>
+    (reference.referencedStoryId !== undefined &&
+        selection.storyIds.has(reference.referencedStoryId)) ||
+    (reference.referencedStoryUuid !== undefined &&
+        selection.storyUuids.has(reference.referencedStoryUuid));
+
+const isInLedger = (
+    reference: CopyGraphStoryReference,
+    copyMaps: CopyMaps,
+): boolean =>
+    (reference.referencedStoryId !== undefined &&
+        copyMaps.storyIds.has(reference.referencedStoryId)) ||
+    (reference.referencedStoryUuid !== undefined &&
+        copyMaps.storyUuids.has(reference.referencedStoryUuid));
+
+export const classifyStoryReferenceStatus = ({
+    reference,
+    selection,
+    copyMaps,
+    sameSpace,
+}: {
+    reference: CopyGraphStoryReference;
+    selection: CopyReferenceSelection;
+    copyMaps: CopyMaps;
+    sameSpace: boolean;
+}): CopyStoryReferenceStatus => {
+    // The scanner already decided these; the copy plan cannot improve on them.
+    if (
+        reference.status === "unresolved" ||
+        reference.status === "unsupported"
+    ) {
+        return reference.status;
+    }
+
+    if (STRUCTURAL_REFERENCE_PATHS.has(reference.path)) {
+        return "will_relink";
+    }
+
+    if (
+        isInSelection(reference, selection) ||
+        isInLedger(reference, copyMaps)
+    ) {
+        return "will_relink";
+    }
+
+    return sameSpace ? "external_kept" : "will_break";
+};
+
+export const classifyStoryReferences = ({
+    storyReferences,
+    selection,
+    copyMaps,
+    sameSpace,
+}: {
+    storyReferences: CopyGraphStoryReference[];
+    selection: CopyReferenceSelection;
+    copyMaps: CopyMaps;
+    sameSpace: boolean;
+}): CopyGraphStoryReference[] =>
+    storyReferences.map((reference) => ({
+        ...reference,
+        status: classifyStoryReferenceStatus({
+            reference,
+            selection,
+            copyMaps,
+            sameSpace,
+        }),
+    }));
+
+export const countStoryReferenceStatuses = (
+    storyReferences: CopyGraphStoryReference[],
+): CopyStoryReferenceStatusCounts => {
+    const counts: CopyStoryReferenceStatusCounts = {
+        willRelink: 0,
+        willBreak: 0,
+        externalKept: 0,
+        unresolved: 0,
+        unsupported: 0,
+        unclassified: 0,
+    };
+
+    for (const reference of storyReferences) {
+        switch (reference.status) {
+            case "will_relink":
+                counts.willRelink += 1;
+                break;
+            case "will_break":
+                counts.willBreak += 1;
+                break;
+            case "external_kept":
+                counts.externalKept += 1;
+                break;
+            case "unresolved":
+                counts.unresolved += 1;
+                break;
+            case "unsupported":
+                counts.unsupported += 1;
+                break;
+            default:
+                counts.unclassified += 1;
+                break;
+        }
+    }
+
+    return counts;
+};
+
+/**
+ * Groups the references that will dangle by the story that holds them, so the
+ * report can name a story once and list its offending field paths under it.
+ */
+export const groupBrokenStoryReferences = (
+    storyReferences: CopyGraphStoryReference[],
+): CopyBrokenStoryReferenceGroup[] => {
+    const groups = new Map<string, CopyBrokenStoryReferenceGroup>();
+
+    for (const reference of storyReferences) {
+        if (reference.status !== "will_break") {
+            continue;
+        }
+
+        const sourceStoryFullSlug =
+            reference.sourceStoryFullSlug ??
+            (reference.sourceStoryId !== undefined
+                ? `#${reference.sourceStoryId}`
+                : "<unknown story>");
+        const group = groups.get(sourceStoryFullSlug) ?? {
+            sourceStoryFullSlug,
+            references: [],
+        };
+
+        group.references.push(reference);
+        groups.set(sourceStoryFullSlug, group);
+    }
+
+    return Array.from(groups.values());
+};
+
+export const describeBrokenStoryReferenceTarget = (
+    reference: CopyGraphStoryReference,
+): string =>
+    reference.referencedStoryUuid ??
+    (reference.referencedStoryId !== undefined
+        ? `#${reference.referencedStoryId}`
+        : "<unknown target>");

--- a/src/api/copy/reference-scanner.ts
+++ b/src/api/copy/reference-scanner.ts
@@ -15,7 +15,6 @@ type StoryLike = {
     uuid?: string;
     full_slug?: string;
     parent_id?: number | null;
-    alternates?: Array<{ id?: number; parent_id?: number | null }>;
     content?: Record<string, unknown>;
 };
 
@@ -150,21 +149,9 @@ const scanStoryMetadata = (story: StoryLike, state: ScannerState) => {
         });
     }
 
-    story.alternates?.forEach((alternate, index) => {
-        if (typeof alternate.id === "number") {
-            addStoryReference(state, {
-                path: `alternates[${index}].id`,
-                referencedStoryId: alternate.id,
-            });
-        }
-
-        if (typeof alternate.parent_id === "number") {
-            addStoryReference(state, {
-                path: `alternates[${index}].parent_id`,
-                referencedStoryId: alternate.parent_id,
-            });
-        }
-    });
+    // `alternates` is read-only API metadata that the copy payload strips
+    // before writing, so it is never rewritten and never dangles. Scanning it
+    // would report references that no copy phase acts on.
 };
 
 const scanComponentNode = (

--- a/src/api/copy/reference-scanner.ts
+++ b/src/api/copy/reference-scanner.ts
@@ -141,7 +141,9 @@ export const scanStoriesReferences = ({
 };
 
 const scanStoryMetadata = (story: StoryLike, state: ScannerState) => {
-    if (typeof story.parent_id === "number") {
+    // parent_id 0 is Storyblok's "lives at the space root" sentinel, not a
+    // story id. Recording it inflated every reference count with a phantom.
+    if (typeof story.parent_id === "number" && story.parent_id !== 0) {
         addStoryReference(state, {
             path: "parent_id",
             referencedStoryId: story.parent_id,
@@ -503,9 +505,12 @@ const addStoryReference = (
         type: "story_reference",
         ...state.context,
         ...reference,
+        // The scanner sees one story at a time, so it cannot know whether the
+        // referenced story is inside the copy plan. The classifier decides
+        // that; see classifyStoryReferences in ./reference-classifier.ts.
         status:
             state.options.referencePolicy === "preserve"
-                ? "preserved_external"
+                ? "unclassified"
                 : "unresolved",
     });
 };

--- a/src/api/copy/types.ts
+++ b/src/api/copy/types.ts
@@ -121,6 +121,28 @@ export type CopyGraphAssetFolderNode = {
     action: CopyGraphAction;
 };
 
+/**
+ * Scope-aware lifecycle of a scanned story reference.
+ *
+ * - `unclassified` — emitted by the scanner, which sees a single story and
+ *   therefore cannot know the copy plan. Replaced by the classifier.
+ * - `will_relink` — the referenced story is inside the selection (its mapping
+ *   will exist by phase 2) or is already in the loaded ledger.
+ * - `will_break` — the referenced story is outside the selection and not in
+ *   the ledger; in a cross-space copy this reference dangles.
+ * - `external_kept` — same-space copy, where pointing at the original story
+ *   remains correct.
+ * - `unresolved` — reference policy `fail`: the reference cannot be handled.
+ * - `unsupported` — the reference shape is not rewritable.
+ */
+export type CopyStoryReferenceStatus =
+    | "unclassified"
+    | "will_relink"
+    | "will_break"
+    | "external_kept"
+    | "unresolved"
+    | "unsupported";
+
 export type CopyGraphStoryReference = {
     type: "story_reference";
     sourceStoryId?: number;
@@ -129,7 +151,7 @@ export type CopyGraphStoryReference = {
     referencedStoryId?: number;
     referencedStoryUuid?: string;
     path: string;
-    status: "mapped" | "preserved_external" | "unresolved" | "unsupported";
+    status: CopyStoryReferenceStatus;
 };
 
 export type CopyGraphAssetReference = {

--- a/src/cli/commands/copy.ts
+++ b/src/cli/commands/copy.ts
@@ -2243,10 +2243,17 @@ const annotateReferencesWithManifestMaps = ({
     graph,
     copyMaps,
     withAssets,
+    classifyStories,
 }: {
     graph: CopyGraph;
     copyMaps: CopyMaps;
     withAssets: boolean;
+    /**
+     * Only a story-copy run rewrites story references, so only it can promise
+     * `will_relink` or warn `will_break`. Asset-only runs leave the scanner's
+     * neutral `unclassified` status in place.
+     */
+    classifyStories: boolean;
 }) => {
     for (const reference of graph.assetReferences) {
         if (hasMappedAssetReference({ ...reference, copyMaps })) {
@@ -2257,6 +2264,10 @@ const annotateReferencesWithManifestMaps = ({
         if (!withAssets && reference.status === "planned") {
             reference.status = "unresolved";
         }
+    }
+
+    if (!classifyStories) {
+        return;
     }
 
     // Story references are classified against the copy plan as well as the
@@ -2328,6 +2339,27 @@ const annotateAssetsWithManifestMaps = ({
     }
 };
 
+/**
+ * Restricts the scan input to the stories the plan will actually write. The
+ * selection fetch can return more than the plan (children mode fetches the
+ * root folder but does not copy it); scanning those would attribute
+ * references to a run that never touches them.
+ */
+const selectPlannedSourceStories = (
+    sourceStories: any[],
+    plan: CopyPlanItem[],
+): any[] => {
+    const plannedFullSlugs = new Set(plan.map((item) => item.sourceFullSlug));
+
+    return sourceStories
+        .map((item) => item?.story)
+        .filter(
+            (story) =>
+                Boolean(story) &&
+                plannedFullSlugs.has(String(story.full_slug ?? "")),
+        );
+};
+
 const buildStoryReferenceDryRunGraph = ({
     sourceSpace,
     targetSpace,
@@ -2360,7 +2392,7 @@ const buildStoryReferenceDryRunGraph = ({
             .map((story) => [String(story.full_slug ?? ""), story] as const),
     );
     const scanResult = scanStoriesReferences({
-        stories: sourceStories.map((item) => item?.story).filter(Boolean),
+        stories: selectPlannedSourceStories(sourceStories, plan),
         schemas,
         options: {
             referencePolicy: "preserve",
@@ -2401,6 +2433,7 @@ const buildStoryReferenceDryRunGraph = ({
         graph,
         copyMaps,
         withAssets: false,
+        classifyStories: true,
     });
 
     return graph;
@@ -2417,6 +2450,7 @@ const buildReferencedAssetsGraph = ({
     sourceAssetFolders,
     schemas,
     copyMaps,
+    classifyStories,
     onScanProgress,
 }: {
     sourceSpace: string;
@@ -2429,6 +2463,7 @@ const buildReferencedAssetsGraph = ({
     sourceAssetFolders: any[];
     schemas: Record<string, any>;
     copyMaps: CopyMaps;
+    classifyStories: boolean;
     onScanProgress?: (progress: {
         scanned: number;
         total: number;
@@ -2436,7 +2471,7 @@ const buildReferencedAssetsGraph = ({
     }) => void;
 }): CopyGraph => {
     const scanResult = scanStoriesReferences({
-        stories: sourceStories.map((item) => item?.story).filter(Boolean),
+        stories: selectPlannedSourceStories(sourceStories, plan),
         schemas,
         options: {
             referencePolicy: "preserve",
@@ -2523,6 +2558,7 @@ const buildReferencedAssetsGraph = ({
         graph,
         copyMaps,
         withAssets: true,
+        classifyStories,
     });
     annotateAssetsWithManifestMaps({
         graph,
@@ -3895,6 +3931,7 @@ export const copyCommand = async (props: CLIOptions) => {
                         sourceAssetFolders,
                         schemas,
                         copyMaps,
+                        classifyStories: true,
                         onScanProgress: logReferenceScanProgress,
                     });
                     Logger.success(
@@ -4147,6 +4184,9 @@ export const copyCommand = async (props: CLIOptions) => {
                     sourceAssetFolders,
                     schemas,
                     copyMaps,
+                    // An asset-only run never rewrites stories, so story
+                    // references stay `unclassified` and never warn.
+                    classifyStories: false,
                     onScanProgress: logReferenceScanProgress,
                 });
                 Logger.success(

--- a/src/cli/commands/copy.ts
+++ b/src/cli/commands/copy.ts
@@ -19,9 +19,14 @@ import {
     appendManifestEntry,
     buildCopyAssetsGraph,
     buildCopyMaps,
+    buildCopyReferenceSelection,
+    classifyStoryReferences,
+    countStoryReferenceStatuses,
     createCopyGraph,
     dedupeManifestFile,
+    describeBrokenStoryReferenceTarget,
     getDefaultCopyManifestPaths,
+    groupBrokenStoryReferences,
     loadManifest,
     normalizeAssetFolderParentId,
     rewriteCopyReferences,
@@ -154,8 +159,9 @@ type CopyDryRunReport = {
         assetsMapped: number;
         assetsToCopy: number;
         storyReferences: number;
-        storyReferencesMapped: number;
-        storyReferencesPreserved: number;
+        storyReferencesWillRelink: number;
+        storyReferencesWillBreak: number;
+        storyReferencesExternalKept: number;
         storyReferencesUnresolved: number;
         conflicts: number;
         warnings: number;
@@ -1404,18 +1410,9 @@ const buildCopyDryRunReport = ({
         graph?.assetReferences.filter(
             (reference) => reference.status === "unresolved",
         ).length ?? 0;
-    const storyReferencesMapped =
-        graph?.storyReferences.filter(
-            (reference) => reference.status === "mapped",
-        ).length ?? 0;
-    const storyReferencesPreserved =
-        graph?.storyReferences.filter(
-            (reference) => reference.status === "preserved_external",
-        ).length ?? 0;
-    const storyReferencesUnresolved =
-        graph?.storyReferences.filter(
-            (reference) => reference.status === "unresolved",
-        ).length ?? 0;
+    const storyReferenceCounts = countStoryReferenceStatuses(
+        graph?.storyReferences ?? [],
+    );
     const assetsMapped =
         graph?.assets.filter((asset) => asset.action === "match").length ?? 0;
     const assetsToCopy =
@@ -1458,9 +1455,10 @@ const buildCopyDryRunReport = ({
             assetsMapped,
             assetsToCopy,
             storyReferences: graphSummary?.storyReferences ?? 0,
-            storyReferencesMapped,
-            storyReferencesPreserved,
-            storyReferencesUnresolved,
+            storyReferencesWillRelink: storyReferenceCounts.willRelink,
+            storyReferencesWillBreak: storyReferenceCounts.willBreak,
+            storyReferencesExternalKept: storyReferenceCounts.externalKept,
+            storyReferencesUnresolved: storyReferenceCounts.unresolved,
             conflicts: conflicts.length,
             warnings: warnings.length + (graphSummary?.warnings ?? 0),
             errors: graphSummary?.errors ?? 0,
@@ -2261,15 +2259,27 @@ const annotateReferencesWithManifestMaps = ({
         }
     }
 
-    for (const reference of graph.storyReferences) {
-        if (
-            (reference.referencedStoryId !== undefined &&
-                copyMaps.storyIds.has(reference.referencedStoryId)) ||
-            (reference.referencedStoryUuid !== undefined &&
-                copyMaps.storyUuids.has(reference.referencedStoryUuid))
-        ) {
-            reference.status = "mapped";
-        }
+    // Story references are classified against the copy plan as well as the
+    // ledger: a reference into the selection relinks once phase 2 runs, one
+    // that points outside it dangles. graph.stories already carries the plan.
+    graph.storyReferences = classifyStoryReferences({
+        storyReferences: graph.storyReferences,
+        selection: buildCopyReferenceSelection(graph.stories),
+        copyMaps,
+        sameSpace: graph.sourceSpaceId === graph.targetSpaceId,
+    });
+
+    for (const group of groupBrokenStoryReferences(graph.storyReferences)) {
+        graph.warnings.push({
+            code: "broken_story_reference",
+            message: `Story '${group.sourceStoryFullSlug}' references ${group.references.length} story/stories outside this copy that are not in the ledger; the copied content will point at nothing.`,
+            path: group.references
+                .map((reference) => reference.path)
+                .join(", "),
+            sourceValue: group.references.map(
+                describeBrokenStoryReferenceTarget,
+            ),
+        });
     }
 };
 
@@ -3614,8 +3624,26 @@ const logDryRunCopyPlan = async ({ report }: { report: CopyDryRunReport }) => {
         }
 
         Logger.warning(
-            `[dry-run] Story refs: ${report.summary.storyReferencesMapped} mapped, ${report.summary.storyReferencesPreserved} preserved, ${report.summary.storyReferencesUnresolved} unresolved.`,
+            `[dry-run] Story refs: ${report.summary.storyReferencesWillRelink} will relink, ${report.summary.storyReferencesWillBreak} will break, ${report.summary.storyReferencesExternalKept} external kept, ${report.summary.storyReferencesUnresolved} unresolved.`,
         );
+
+        if (report.summary.storyReferencesWillBreak > 0) {
+            Logger.error(
+                `[dry-run] ${report.summary.storyReferencesWillBreak} story reference(s) WILL BREAK: they point at stories outside this copy and are not in the ledger, so the copied content will point at nothing.`,
+            );
+
+            for (const group of groupBrokenStoryReferences(
+                report.graph.storyReferences,
+            )) {
+                Logger.error(`[dry-run]   ${group.sourceStoryFullSlug}`);
+
+                for (const reference of group.references) {
+                    Logger.error(
+                        `[dry-run]     ${reference.path} -> ${describeBrokenStoryReferenceTarget(reference)}`,
+                    );
+                }
+            }
+        }
 
         for (const folder of report.graph.assetFolders) {
             Logger.warning(


### PR DESCRIPTION
## What

`copy stories` could not tell a story reference that will relink from one that will dangle. `addStoryReference` stamped **every** scanned reference `preserved_external`, because the scanner sees one story at a time and cannot know the copy plan.

The result was a dry-run that lied in both directions. On the probe fixture a run reported `Story refs: 0 mapped, 15 preserved` — and then relinked almost all of them. This is very likely where the belief that copy "never handles references" came from.

## How

A new `src/api/copy/reference-classifier.ts` classifies each scanned reference against the copy plan **and** the ledger:

| Status | Meaning |
| --- | --- |
| `will_relink` | referenced story is inside the selection (its mapping exists by phase 2) or is already in the loaded ledger |
| `will_break` | outside the selection and not in the ledger — in a cross-space copy this dangles |
| `external_kept` | same-space copy, where continuing to point at the original is correct |
| `unclassified` | the scanner's pre-classification output, replaced before the graph is reported |

When `will_break > 0` the dry-run prints a loud report naming each holding story and field path, and the graph carries a `broken_story_reference` warning per story. The summary exposes `storyReferencesWillRelink` / `storyReferencesWillBreak` / `storyReferencesExternalKept` in place of the old `Mapped` / `Preserved` fields.

Two smaller corrections come with it:

- **`parent_id: 0` is no longer recorded as a reference.** Zero is Storyblok's "lives at the space root" sentinel, not a story id; the phantom inflated every count by one per root-level item.
- **`parent_id` is always `will_relink`.** Phase 1 creates each shell under its planned parent and the top of the selection lands under the destination, so it cannot dangle the way a content reference can. Without this, every "copy a subtree into root" run would report a fake break.

The rewriting machinery is untouched — this is the honesty layer around it.

## Verification

`npm run test:unit` — 57 files, 594 tests, all passing. 17 new classifier tests; the scanner and dry-run suites were updated for the new vocabulary.

`npm run build && node dist/cli/index.js copy` routes; full dry-runs executed end to end against live spaces.

Live cross-space dry-runs against the probe fixture, with summary counts reproduced by counting the emitted graph directly:

| Run | Refs | will_relink | will_break |
| --- | --- | --- | --- |
| whole subtree | 18 | 17 | 1 |
| `pages` only | 14 | 6 | 8 |
| `pages` only, ledger present | 14 | 13 | 1 |

- The single break in the whole-subtree run is the one reference that genuinely points at a story outside the source folder.
- The 8 breaks in the `pages`-only run are that same out-of-scope link plus page-one's seven references to a story deliberately left out of the selection.
- With the ledger present those seven flip to `will_relink`, because the referenced story was copied by an earlier run — leaving only the genuinely external one. That is the ledger arm of the classifier, proven live.

Closes MAR-2670.
