### PR TITLE
feat(copy): plan gate before any write, --yes and --fresh (MAR-2669)

### DIFF
--- a/__tests__/api/copy-manifest.test.ts
+++ b/__tests__/api/copy-manifest.test.ts
@@ -220,11 +220,11 @@ describe("copy graph model", () => {
             sourceStoryId: 100,
             referencedStoryId: 101,
             path: "content.related[0]",
-            status: "preserved_external",
+            status: "will_break",
         });
         graph.warnings.push({
-            code: "external_story_reference",
-            message: "External story reference preserved.",
+            code: "broken_story_reference",
+            message: "Story reference points outside this copy.",
         });
 
         expect(graph).toMatchObject({

--- a/__tests__/api/copy-plan-gate.test.ts
+++ b/__tests__/api/copy-plan-gate.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
     buildCopyPlanGateSummary,
     createCopyGraph,
-    createEmptyCopyMaps,
     formatCopyPlanGate,
 } from "../../src/api/copy/index.js";
 
@@ -16,19 +15,16 @@ const ledger = {
 const plan = [
     {
         type: "folder" as const,
-        sourceId: 1,
         sourceFullSlug: "blog",
         targetFullSlug: "imported/blog",
     },
     {
         type: "story" as const,
-        sourceId: 2,
         sourceFullSlug: "blog/post-1",
         targetFullSlug: "imported/blog/post-1",
     },
     {
         type: "story" as const,
-        sourceId: 3,
         sourceFullSlug: "blog/post-2",
         targetFullSlug: "imported/blog/post-2",
     },
@@ -52,6 +48,7 @@ const graphWithReferences = () => {
         {
             type: "story_reference",
             sourceStoryId: 2,
+            sourceStoryFullSlug: "blog/post-1",
             referencedStoryId: 3,
             path: "content.related[0]",
             status: "will_relink",
@@ -59,6 +56,7 @@ const graphWithReferences = () => {
         {
             type: "story_reference",
             sourceStoryId: 2,
+            sourceStoryFullSlug: "blog/post-1",
             referencedStoryUuid: "shared-header-uuid",
             path: "content.header",
             status: "will_break",
@@ -66,6 +64,7 @@ const graphWithReferences = () => {
         {
             type: "story_reference",
             sourceStoryId: 3,
+            sourceStoryFullSlug: "blog/post-2",
             referencedStoryUuid: "shared-footer-uuid",
             path: "content.footer",
             status: "external_kept",
@@ -91,20 +90,25 @@ const graphWithReferences = () => {
 
 describe("copy plan gate", () => {
     describe("buildCopyPlanGateSummary", () => {
-        it("splits the plan into create, adopt and resume by ledger first, then target path", () => {
-            const copyMaps = createEmptyCopyMaps();
-            copyMaps.storyIds.set(2, 9002);
-
+        it("splits the plan into create, adopt and resume", () => {
             const summary = buildCopyPlanGateSummary({
                 sourceSpaceId: "111",
                 targetSpaceId: "222",
-                plan,
-                // post-1 also exists at the target, but the ledger wins.
-                conflictTargetFullSlugs: [
-                    "imported/blog/post-1",
-                    "imported/blog/post-2",
+                plan: [
+                    plan[0],
+                    {
+                        // Mapped by the ledger to the story that really sits at
+                        // the target path: a resume.
+                        ...plan[1],
+                        ledgerTargetStoryId: 9002,
+                        existingTargetStoryId: 9002,
+                    },
+                    {
+                        // Unmapped, but the path is taken: adopted in place.
+                        ...plan[2],
+                        existingTargetStoryId: 9003,
+                    },
                 ],
-                copyMaps,
                 ledger: { ...ledger, entries: 1 },
                 withAssets: false,
             });
@@ -115,6 +119,7 @@ describe("copy plan gate", () => {
                 create: 1,
                 resume: 1,
                 adopt: 1,
+                staleLedger: 0,
             });
             expect(summary.references).toEqual({
                 scanned: false,
@@ -122,8 +127,42 @@ describe("copy plan gate", () => {
                 willRelink: 0,
                 willBreak: 0,
                 externalKept: 0,
+                breaking: [],
             });
             expect(summary.assets).toBeUndefined();
+        });
+
+        it("discards ledger mappings the target no longer backs", () => {
+            const summary = buildCopyPlanGateSummary({
+                sourceSpaceId: "111",
+                targetSpaceId: "222",
+                plan: [
+                    plan[0],
+                    {
+                        // Mapped, but the target story is gone: a create.
+                        ...plan[1],
+                        ledgerTargetStoryId: 5555,
+                    },
+                    {
+                        // Mapped, but a different story holds the path now:
+                        // the run adopts that one instead.
+                        ...plan[2],
+                        ledgerTargetStoryId: 5556,
+                        existingTargetStoryId: 9003,
+                    },
+                ],
+                ledger: { ...ledger, entries: 2 },
+                withAssets: false,
+            });
+
+            expect(summary.stories).toEqual({
+                total: 3,
+                folders: 1,
+                create: 2,
+                resume: 0,
+                adopt: 1,
+                staleLedger: 2,
+            });
         });
 
         it("counts classified references and planned assets from the graph", () => {
@@ -131,42 +170,27 @@ describe("copy plan gate", () => {
                 sourceSpaceId: "111",
                 targetSpaceId: "222",
                 plan,
-                conflictTargetFullSlugs: [],
-                copyMaps: createEmptyCopyMaps(),
                 ledger,
                 graph: graphWithReferences(),
                 withAssets: true,
             });
 
-            expect(summary.references).toEqual({
+            expect(summary.references).toMatchObject({
                 scanned: true,
                 total: 3,
                 willRelink: 1,
                 willBreak: 1,
                 externalKept: 1,
             });
+            expect(summary.references.breaking).toEqual([
+                {
+                    sourceStoryFullSlug: "blog/post-1",
+                    references: [
+                        expect.objectContaining({ path: "content.header" }),
+                    ],
+                },
+            ]);
             expect(summary.assets).toEqual({ toCopy: 1, mapped: 1 });
-        });
-
-        it("treats plan items without a resolved source id as creates", () => {
-            const copyMaps = createEmptyCopyMaps();
-            copyMaps.storyIds.set(2, 9002);
-
-            const summary = buildCopyPlanGateSummary({
-                sourceSpaceId: "111",
-                targetSpaceId: "222",
-                plan: plan.map(({ sourceId: _sourceId, ...item }) => item),
-                conflictTargetFullSlugs: [],
-                copyMaps,
-                ledger,
-                withAssets: false,
-            });
-
-            expect(summary.stories).toMatchObject({
-                create: 3,
-                resume: 0,
-                adopt: 0,
-            });
         });
     });
 
@@ -177,8 +201,6 @@ describe("copy plan gate", () => {
                     sourceSpaceId: "111",
                     targetSpaceId: "222",
                     plan,
-                    conflictTargetFullSlugs: [],
-                    copyMaps: createEmptyCopyMaps(),
                     ledger,
                     withAssets: false,
                 }),
@@ -194,16 +216,19 @@ describe("copy plan gate", () => {
         });
 
         it("names adoption, resumption, breaking references and assets", () => {
-            const copyMaps = createEmptyCopyMaps();
-            copyMaps.storyIds.set(3, 9003);
-
             const lines = formatCopyPlanGate(
                 buildCopyPlanGateSummary({
                     sourceSpaceId: "111",
                     targetSpaceId: "222",
-                    plan,
-                    conflictTargetFullSlugs: ["imported/blog/post-1"],
-                    copyMaps,
+                    plan: [
+                        plan[0],
+                        { ...plan[1], existingTargetStoryId: 9002 },
+                        {
+                            ...plan[2],
+                            ledgerTargetStoryId: 9003,
+                            existingTargetStoryId: 9003,
+                        },
+                    ],
                     ledger: { ...ledger, entries: 11 },
                     graph: graphWithReferences(),
                     withAssets: true,
@@ -216,8 +241,64 @@ describe("copy plan gate", () => {
                 "    1 existing target path will be adopted and UPDATED in place.",
                 "  ledger: 11 entries loaded from /repo/.sb-mig/copy/111/222/manifest.jsonl (resuming; use --fresh to ignore)",
                 "  references: 1 will relink, 1 leave your selection and WILL BREAK",
+                "    WILL BREAK, by story:",
+                "      blog/post-1",
+                "        content.header -> shared-header-uuid",
                 "  assets: 1 will copy, 1 already mapped",
             ]);
+        });
+
+        it("says how many ledger mappings went stale", () => {
+            const lines = formatCopyPlanGate(
+                buildCopyPlanGateSummary({
+                    sourceSpaceId: "111",
+                    targetSpaceId: "222",
+                    plan: [
+                        { ...plan[0], ledgerTargetStoryId: 5554 },
+                        { ...plan[1], ledgerTargetStoryId: 5555 },
+                        plan[2],
+                    ],
+                    ledger: { ...ledger, entries: 2 },
+                    withAssets: false,
+                }),
+            );
+
+            expect(lines[1]).toBe(
+                "  3 items (1 folder) -> space 222 (3 create, 0 adopt existing, 0 resume from ledger)",
+            );
+            expect(lines[2]).toBe(
+                "    2 ledger mappings no longer resolve in space 222 and will be discarded.",
+            );
+        });
+
+        it("caps the broken-reference listing and points at the dry run", () => {
+            const graph = graphWithReferences();
+
+            graph.storyReferences = Array.from({ length: 23 }, (_, index) => ({
+                type: "story_reference" as const,
+                sourceStoryId: 100 + index,
+                sourceStoryFullSlug: `blog/post-${index}`,
+                referencedStoryUuid: "shared-header-uuid",
+                path: "content.header",
+                status: "will_break" as const,
+            }));
+
+            const lines = formatCopyPlanGate(
+                buildCopyPlanGateSummary({
+                    sourceSpaceId: "111",
+                    targetSpaceId: "222",
+                    plan,
+                    ledger,
+                    graph,
+                    withAssets: false,
+                }),
+            );
+
+            expect(lines).toContain("      blog/post-19");
+            expect(lines).not.toContain("      blog/post-20");
+            expect(lines).toContain(
+                "      ...and 3 more stories with breaking references; run with --dryRun for the full list.",
+            );
         });
 
         it("marks an ignored ledger and shows kept references on a same-space copy", () => {
@@ -226,8 +307,6 @@ describe("copy plan gate", () => {
                     sourceSpaceId: "111",
                     targetSpaceId: "111",
                     plan,
-                    conflictTargetFullSlugs: [],
-                    copyMaps: createEmptyCopyMaps(),
                     ledger: { ...ledger, entries: 1, ignored: true },
                     graph: graphWithReferences(),
                     withAssets: false,

--- a/__tests__/api/copy-plan-gate.test.ts
+++ b/__tests__/api/copy-plan-gate.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    buildCopyPlanGateSummary,
+    createCopyGraph,
+    createEmptyCopyMaps,
+    formatCopyPlanGate,
+} from "../../src/api/copy/index.js";
+
+const ledger = {
+    path: "/repo/.sb-mig/copy/111/222/manifest.jsonl",
+    entries: 0,
+    ignored: false,
+};
+
+const plan = [
+    {
+        type: "folder" as const,
+        sourceId: 1,
+        sourceFullSlug: "blog",
+        targetFullSlug: "imported/blog",
+    },
+    {
+        type: "story" as const,
+        sourceId: 2,
+        sourceFullSlug: "blog/post-1",
+        targetFullSlug: "imported/blog/post-1",
+    },
+    {
+        type: "story" as const,
+        sourceId: 3,
+        sourceFullSlug: "blog/post-2",
+        targetFullSlug: "imported/blog/post-2",
+    },
+];
+
+const graphWithReferences = () => {
+    const graph = createCopyGraph({
+        sourceSpaceId: "111",
+        targetSpaceId: "222",
+        scope: {
+            command: "copy stories",
+            source: "blog",
+            destination: "imported",
+            mode: "subtree",
+            withAssets: true,
+            referencePolicy: "preserve",
+        },
+    });
+
+    graph.storyReferences.push(
+        {
+            type: "story_reference",
+            sourceStoryId: 2,
+            referencedStoryId: 3,
+            path: "content.related[0]",
+            status: "will_relink",
+        },
+        {
+            type: "story_reference",
+            sourceStoryId: 2,
+            referencedStoryUuid: "shared-header-uuid",
+            path: "content.header",
+            status: "will_break",
+        },
+        {
+            type: "story_reference",
+            sourceStoryId: 3,
+            referencedStoryUuid: "shared-footer-uuid",
+            path: "content.footer",
+            status: "external_kept",
+        },
+    );
+    graph.assets.push(
+        {
+            type: "asset",
+            sourceId: 300,
+            sourceFilename: "https://a.storyblok.com/f/111/a.jpg",
+            action: "create",
+        },
+        {
+            type: "asset",
+            sourceId: 301,
+            sourceFilename: "https://a.storyblok.com/f/111/b.jpg",
+            action: "match",
+        },
+    );
+
+    return graph;
+};
+
+describe("copy plan gate", () => {
+    describe("buildCopyPlanGateSummary", () => {
+        it("splits the plan into create, adopt and resume by ledger first, then target path", () => {
+            const copyMaps = createEmptyCopyMaps();
+            copyMaps.storyIds.set(2, 9002);
+
+            const summary = buildCopyPlanGateSummary({
+                sourceSpaceId: "111",
+                targetSpaceId: "222",
+                plan,
+                // post-1 also exists at the target, but the ledger wins.
+                conflictTargetFullSlugs: [
+                    "imported/blog/post-1",
+                    "imported/blog/post-2",
+                ],
+                copyMaps,
+                ledger: { ...ledger, entries: 1 },
+                withAssets: false,
+            });
+
+            expect(summary.stories).toEqual({
+                total: 3,
+                folders: 1,
+                create: 1,
+                resume: 1,
+                adopt: 1,
+            });
+            expect(summary.references).toEqual({
+                scanned: false,
+                total: 0,
+                willRelink: 0,
+                willBreak: 0,
+                externalKept: 0,
+            });
+            expect(summary.assets).toBeUndefined();
+        });
+
+        it("counts classified references and planned assets from the graph", () => {
+            const summary = buildCopyPlanGateSummary({
+                sourceSpaceId: "111",
+                targetSpaceId: "222",
+                plan,
+                conflictTargetFullSlugs: [],
+                copyMaps: createEmptyCopyMaps(),
+                ledger,
+                graph: graphWithReferences(),
+                withAssets: true,
+            });
+
+            expect(summary.references).toEqual({
+                scanned: true,
+                total: 3,
+                willRelink: 1,
+                willBreak: 1,
+                externalKept: 1,
+            });
+            expect(summary.assets).toEqual({ toCopy: 1, mapped: 1 });
+        });
+
+        it("treats plan items without a resolved source id as creates", () => {
+            const copyMaps = createEmptyCopyMaps();
+            copyMaps.storyIds.set(2, 9002);
+
+            const summary = buildCopyPlanGateSummary({
+                sourceSpaceId: "111",
+                targetSpaceId: "222",
+                plan: plan.map(({ sourceId: _sourceId, ...item }) => item),
+                conflictTargetFullSlugs: [],
+                copyMaps,
+                ledger,
+                withAssets: false,
+            });
+
+            expect(summary.stories).toMatchObject({
+                create: 3,
+                resume: 0,
+                adopt: 0,
+            });
+        });
+    });
+
+    describe("formatCopyPlanGate", () => {
+        it("prints an empty ledger, unscanned references and no assets honestly", () => {
+            const lines = formatCopyPlanGate(
+                buildCopyPlanGateSummary({
+                    sourceSpaceId: "111",
+                    targetSpaceId: "222",
+                    plan,
+                    conflictTargetFullSlugs: [],
+                    copyMaps: createEmptyCopyMaps(),
+                    ledger,
+                    withAssets: false,
+                }),
+            );
+
+            expect(lines).toEqual([
+                "PLAN",
+                "  3 items (1 folder) -> space 222 (3 create, 0 adopt existing, 0 resume from ledger)",
+                "  ledger: none at /repo/.sb-mig/copy/111/222/manifest.jsonl (starting empty)",
+                "  references: not scanned",
+                "  assets: not copied (pass --with-assets)",
+            ]);
+        });
+
+        it("names adoption, resumption, breaking references and assets", () => {
+            const copyMaps = createEmptyCopyMaps();
+            copyMaps.storyIds.set(3, 9003);
+
+            const lines = formatCopyPlanGate(
+                buildCopyPlanGateSummary({
+                    sourceSpaceId: "111",
+                    targetSpaceId: "222",
+                    plan,
+                    conflictTargetFullSlugs: ["imported/blog/post-1"],
+                    copyMaps,
+                    ledger: { ...ledger, entries: 11 },
+                    graph: graphWithReferences(),
+                    withAssets: true,
+                }),
+            );
+
+            expect(lines).toEqual([
+                "PLAN",
+                "  3 items (1 folder) -> space 222 (1 create, 1 adopt existing, 1 resume from ledger)",
+                "    1 existing target path will be adopted and UPDATED in place.",
+                "  ledger: 11 entries loaded from /repo/.sb-mig/copy/111/222/manifest.jsonl (resuming; use --fresh to ignore)",
+                "  references: 1 will relink, 1 leave your selection and WILL BREAK",
+                "  assets: 1 will copy, 1 already mapped",
+            ]);
+        });
+
+        it("marks an ignored ledger and shows kept references on a same-space copy", () => {
+            const lines = formatCopyPlanGate(
+                buildCopyPlanGateSummary({
+                    sourceSpaceId: "111",
+                    targetSpaceId: "111",
+                    plan,
+                    conflictTargetFullSlugs: [],
+                    copyMaps: createEmptyCopyMaps(),
+                    ledger: { ...ledger, entries: 1, ignored: true },
+                    graph: graphWithReferences(),
+                    withAssets: false,
+                }),
+            );
+
+            expect(lines[2]).toBe(
+                "  ledger: 1 entry at /repo/.sb-mig/copy/111/222/manifest.jsonl IGNORED (--fresh; starting empty)",
+            );
+            expect(lines[3]).toBe(
+                "  references: 1 will relink, 1 outside the selection kept (same space), 1 leave your selection and WILL BREAK",
+            );
+        });
+    });
+});

--- a/__tests__/api/copy-reference-classifier.test.ts
+++ b/__tests__/api/copy-reference-classifier.test.ts
@@ -195,17 +195,6 @@ describe("copy reference classifier", () => {
             expect(classified.status).toBe("will_relink");
         });
 
-        it("does classify alternates as ordinary content references", () => {
-            const [classified] = classify([
-                reference({
-                    path: "alternates[0].parent_id",
-                    referencedStoryId: 999,
-                }),
-            ]);
-
-            expect(classified.status).toBe("will_break");
-        });
-
         it("leaves scanner-decided statuses untouched", () => {
             const classified = classify([
                 reference({

--- a/__tests__/api/copy-reference-classifier.test.ts
+++ b/__tests__/api/copy-reference-classifier.test.ts
@@ -1,0 +1,330 @@
+import type {
+    CopyGraphStoryNode,
+    CopyGraphStoryReference,
+    CopyMaps,
+} from "../../src/api/copy/types.js";
+
+import { describe, expect, it } from "vitest";
+
+import {
+    buildCopyReferenceSelection,
+    classifyStoryReferences,
+    countStoryReferenceStatuses,
+    createEmptyCopyMaps,
+    createEmptyCopyReferenceSelection,
+    describeBrokenStoryReferenceTarget,
+    groupBrokenStoryReferences,
+} from "../../src/api/copy/index.js";
+
+const storyNode = (
+    sourceId: number,
+    sourceUuid: string,
+    sourceFullSlug: string,
+): CopyGraphStoryNode => ({
+    type: "story",
+    sourceId,
+    sourceUuid,
+    sourceFullSlug,
+    action: "create",
+});
+
+const reference = (
+    overrides: Partial<CopyGraphStoryReference>,
+): CopyGraphStoryReference => ({
+    type: "story_reference",
+    sourceStoryId: 10,
+    sourceStoryUuid: "page-one-uuid",
+    sourceStoryFullSlug: "probe/pages/page-one",
+    path: "content.ref_link.id",
+    status: "unclassified",
+    ...overrides,
+});
+
+const ledgerWith = ({
+    storyIds = [] as Array<[number, number]>,
+    storyUuids = [] as Array<[string, string]>,
+}): CopyMaps => {
+    const maps = createEmptyCopyMaps();
+
+    for (const [source, target] of storyIds) {
+        maps.storyIds.set(source, target);
+    }
+
+    for (const [source, target] of storyUuids) {
+        maps.storyUuids.set(source, target);
+    }
+
+    return maps;
+};
+
+const classify = (
+    references: CopyGraphStoryReference[],
+    {
+        stories = [] as CopyGraphStoryNode[],
+        copyMaps = createEmptyCopyMaps(),
+        sameSpace = false,
+    } = {},
+) =>
+    classifyStoryReferences({
+        storyReferences: references,
+        selection: buildCopyReferenceSelection(stories),
+        copyMaps,
+        sameSpace,
+    });
+
+describe("copy reference classifier", () => {
+    describe("buildCopyReferenceSelection", () => {
+        it("collects plan story ids and uuids", () => {
+            const selection = buildCopyReferenceSelection([
+                storyNode(10, "page-one-uuid", "probe/pages/page-one"),
+                storyNode(11, "page-two-uuid", "probe/pages/page-two"),
+            ]);
+
+            expect(Array.from(selection.storyIds)).toEqual([10, 11]);
+            expect(Array.from(selection.storyUuids)).toEqual([
+                "page-one-uuid",
+                "page-two-uuid",
+            ]);
+        });
+
+        it("ignores unresolved plan items carrying sourceId 0", () => {
+            const selection = buildCopyReferenceSelection([
+                { ...storyNode(0, "", "probe/pages"), sourceUuid: undefined },
+            ]);
+
+            expect(selection.storyIds.size).toBe(0);
+            expect(selection.storyUuids.size).toBe(0);
+        });
+
+        it("creates an empty selection", () => {
+            const selection = createEmptyCopyReferenceSelection();
+
+            expect(selection.storyIds.size).toBe(0);
+            expect(selection.storyUuids.size).toBe(0);
+        });
+    });
+
+    describe("classifyStoryReferences", () => {
+        it("marks a reference into the selection will_relink by uuid", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryUuid: "shared-header-uuid" })],
+                {
+                    stories: [
+                        storyNode(
+                            20,
+                            "shared-header-uuid",
+                            "probe/shared/shared-header",
+                        ),
+                    ],
+                },
+            );
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("marks a reference into the selection will_relink by id", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryId: 20 })],
+                {
+                    stories: [
+                        storyNode(
+                            20,
+                            "shared-header-uuid",
+                            "probe/shared/shared-header",
+                        ),
+                    ],
+                },
+            );
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("marks a reference already in the ledger will_relink", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryUuid: "earlier-copy-uuid" })],
+                {
+                    copyMaps: ledgerWith({
+                        storyUuids: [["earlier-copy-uuid", "target-uuid"]],
+                    }),
+                },
+            );
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("marks an out-of-scope reference will_break in a cross-space copy", () => {
+            const [classified] = classify([
+                reference({ referencedStoryUuid: "playground-page-uuid" }),
+            ]);
+
+            expect(classified.status).toBe("will_break");
+        });
+
+        it("marks an out-of-scope reference external_kept in a same-space copy", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryUuid: "playground-page-uuid" })],
+                { sameSpace: true },
+            );
+
+            expect(classified.status).toBe("external_kept");
+        });
+
+        it("still relinks in-scope references in a same-space copy", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryUuid: "shared-header-uuid" })],
+                {
+                    sameSpace: true,
+                    stories: [
+                        storyNode(
+                            20,
+                            "shared-header-uuid",
+                            "probe/shared/shared-header",
+                        ),
+                    ],
+                },
+            );
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("never breaks parent_id, which the copy plan resolves structurally", () => {
+            const [classified] = classify([
+                reference({ path: "parent_id", referencedStoryId: 999 }),
+            ]);
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("does classify alternates as ordinary content references", () => {
+            const [classified] = classify([
+                reference({
+                    path: "alternates[0].parent_id",
+                    referencedStoryId: 999,
+                }),
+            ]);
+
+            expect(classified.status).toBe("will_break");
+        });
+
+        it("leaves scanner-decided statuses untouched", () => {
+            const classified = classify([
+                reference({
+                    referencedStoryUuid: "playground-page-uuid",
+                    status: "unresolved",
+                }),
+                reference({
+                    referencedStoryUuid: "playground-page-uuid",
+                    status: "unsupported",
+                }),
+            ]);
+
+            expect(classified.map((item) => item.status)).toEqual([
+                "unresolved",
+                "unsupported",
+            ]);
+        });
+
+        it("does not mutate the references it is given", () => {
+            const original = reference({
+                referencedStoryUuid: "playground-page-uuid",
+            });
+
+            classify([original]);
+
+            expect(original.status).toBe("unclassified");
+        });
+    });
+
+    describe("countStoryReferenceStatuses", () => {
+        it("counts every status bucket", () => {
+            const counts = countStoryReferenceStatuses([
+                reference({ status: "will_relink" }),
+                reference({ status: "will_relink" }),
+                reference({ status: "will_break" }),
+                reference({ status: "external_kept" }),
+                reference({ status: "unresolved" }),
+                reference({ status: "unsupported" }),
+                reference({ status: "unclassified" }),
+            ]);
+
+            expect(counts).toEqual({
+                willRelink: 2,
+                willBreak: 1,
+                externalKept: 1,
+                unresolved: 1,
+                unsupported: 1,
+                unclassified: 1,
+            });
+        });
+    });
+
+    describe("groupBrokenStoryReferences", () => {
+        it("groups breaks by the story that holds them", () => {
+            const groups = groupBrokenStoryReferences([
+                reference({
+                    status: "will_break",
+                    path: "content.ref_link.id",
+                    referencedStoryUuid: "outside-uuid",
+                }),
+                reference({
+                    status: "will_break",
+                    path: "content.body[0].reference",
+                    referencedStoryUuid: "outside-uuid",
+                }),
+                reference({
+                    status: "will_relink",
+                    path: "content.related",
+                }),
+                reference({
+                    status: "will_break",
+                    sourceStoryFullSlug: "probe/pages/page-four",
+                    path: "content.ref_link.id",
+                    referencedStoryId: 777,
+                }),
+            ]);
+
+            expect(
+                groups.map((group) => [
+                    group.sourceStoryFullSlug,
+                    group.references.map((item) => item.path),
+                ]),
+            ).toEqual([
+                [
+                    "probe/pages/page-one",
+                    ["content.ref_link.id", "content.body[0].reference"],
+                ],
+                ["probe/pages/page-four", ["content.ref_link.id"]],
+            ]);
+        });
+
+        it("falls back to the source story id when the slug is missing", () => {
+            const [group] = groupBrokenStoryReferences([
+                reference({
+                    status: "will_break",
+                    sourceStoryFullSlug: undefined,
+                    sourceStoryId: 42,
+                }),
+            ]);
+
+            expect(group.sourceStoryFullSlug).toBe("#42");
+        });
+    });
+
+    describe("describeBrokenStoryReferenceTarget", () => {
+        it("prefers the uuid, then the id", () => {
+            expect(
+                describeBrokenStoryReferenceTarget(
+                    reference({ referencedStoryUuid: "outside-uuid" }),
+                ),
+            ).toBe("outside-uuid");
+            expect(
+                describeBrokenStoryReferenceTarget(
+                    reference({ referencedStoryId: 777 }),
+                ),
+            ).toBe("#777");
+            expect(describeBrokenStoryReferenceTarget(reference({}))).toBe(
+                "<unknown target>",
+            );
+        });
+    });
+});

--- a/__tests__/api/copy-reference-scanner.test.ts
+++ b/__tests__/api/copy-reference-scanner.test.ts
@@ -31,6 +31,7 @@ const story = {
     uuid: "story-uuid-100",
     full_slug: "blog/post",
     parent_id: 90,
+    // Read-only API metadata: stripped before write, so never scanned.
     alternates: [{ id: 101, parent_id: 91 }],
     content: {
         component: "page",
@@ -205,16 +206,6 @@ describe("copy reference scanner", () => {
             expect.objectContaining({
                 referencedStoryId: 90,
                 path: "parent_id",
-                status: "unclassified",
-            }),
-            expect.objectContaining({
-                referencedStoryId: 101,
-                path: "alternates[0].id",
-                status: "unclassified",
-            }),
-            expect.objectContaining({
-                referencedStoryId: 91,
-                path: "alternates[0].parent_id",
                 status: "unclassified",
             }),
             expect.objectContaining({

--- a/__tests__/api/copy-reference-scanner.test.ts
+++ b/__tests__/api/copy-reference-scanner.test.ts
@@ -205,42 +205,42 @@ describe("copy reference scanner", () => {
             expect.objectContaining({
                 referencedStoryId: 90,
                 path: "parent_id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 101,
                 path: "alternates[0].id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 91,
                 path: "alternates[0].parent_id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 102,
                 path: "content.hero[0].cta.id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryUuid: "story-uuid-103",
                 path: "content.hero[0].body.content[0].content[0].attrs.uuid",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 104,
                 path: "content.hero[0].body.content[1].attrs.body[0].link.id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 105,
                 path: "content.related[0]",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 106,
                 path: "content.related[1]",
-                status: "preserved_external",
+                status: "unclassified",
             }),
         ]);
 

--- a/__tests__/cli/copy-assets-dry-run.test.ts
+++ b/__tests__/cli/copy-assets-dry-run.test.ts
@@ -453,6 +453,18 @@ describe("copy assets dry-run", () => {
                 status: "planned",
             },
         ]);
+        // An asset-only run never rewrites stories, so story references keep
+        // the scanner's neutral status and raise no break warnings.
+        expect(
+            report.graph.storyReferences.every(
+                (reference: any) => reference.status === "unclassified",
+            ),
+        ).toBe(true);
+        expect(
+            report.graph.warnings.filter(
+                (warning: any) => warning.code === "broken_story_reference",
+            ),
+        ).toEqual([]);
         expect(report.commands.apply).toBe(
             "sb-mig copy assets --from source-space --to target-space --referenced-by-stories --source blog/post --mode subtree",
         );

--- a/__tests__/cli/copy-dry-run.test.ts
+++ b/__tests__/cli/copy-dry-run.test.ts
@@ -552,7 +552,13 @@ describe("copy stories dry-run", () => {
                 assetFolders: 2,
                 assets: 1,
                 assetReferences: 1,
-                storyReferences: 4,
+                // parent_id 0 (the space root) is not a story reference: blog
+                // -> post-1, post-1 -> blog, and post-1's parent_id.
+                storyReferences: 3,
+                storyReferencesWillRelink: 3,
+                storyReferencesWillBreak: 0,
+                storyReferencesExternalKept: 0,
+                storyReferencesUnresolved: 0,
                 errors: 0,
             },
             graph: {
@@ -1531,19 +1537,21 @@ describe("copy stories dry-run", () => {
             },
         });
         const getStoryBySlug = mocks.getStoryBySlug.getMockImplementation();
-        mocks.getStoryBySlug.mockImplementation((slug: string, options: any) => {
-            if (slug === "imported/blog") {
-                return Promise.resolve({
-                    story: {
-                        id: 9999,
-                        uuid: "stale-target-blog-uuid",
-                        full_slug: "imported/blog",
-                    },
-                });
-            }
+        mocks.getStoryBySlug.mockImplementation(
+            (slug: string, options: any) => {
+                if (slug === "imported/blog") {
+                    return Promise.resolve({
+                        story: {
+                            id: 9999,
+                            uuid: "stale-target-blog-uuid",
+                            full_slug: "imported/blog",
+                        },
+                    });
+                }
 
-            return getStoryBySlug?.(slug, options);
-        });
+                return getStoryBySlug?.(slug, options);
+            },
+        );
         mocks.updateStory
             .mockResolvedValueOnce({
                 ok: false,

--- a/__tests__/cli/copy-dry-run.test.ts
+++ b/__tests__/cli/copy-dry-run.test.ts
@@ -78,6 +78,13 @@ vi.mock("../../src/utils/logger.js", () => ({
 }));
 
 import { copyCommand } from "../../src/cli/commands/copy.js";
+import Logger from "../../src/utils/logger.js";
+
+/** Every line the PLAN block printed, in order. */
+const planGateLines = () =>
+    (Logger.log as unknown as ReturnType<typeof vi.fn>).mock.calls.map((call) =>
+        String(call[0]),
+    );
 
 describe("copy stories dry-run", () => {
     const sourceAsset = {
@@ -1091,6 +1098,174 @@ describe("copy stories dry-run", () => {
             expect(combined.map((entry) => entry.source_id)).toEqual([1, 2]);
 
             await rm(tempDir, { recursive: true, force: true });
+        });
+
+        const writeStaleLedger = async (manifestRoot: string) => {
+            const manifestDirectory = path.join(
+                manifestRoot,
+                "copy",
+                "source-space",
+                "target-space",
+            );
+
+            await mkdir(manifestDirectory, { recursive: true });
+            await writeFile(
+                path.join(manifestDirectory, "manifest.jsonl"),
+                JSON.stringify({
+                    type: "story",
+                    source_space_id: "source-space",
+                    target_space_id: "target-space",
+                    source_id: 2,
+                    target_id: 5555,
+                    source_uuid: "source-post-uuid",
+                    target_uuid: "stale-target-post-uuid",
+                    source_full_slug: "blog/post-1",
+                    target_full_slug: "imported/blog/post-1",
+                    action: "created",
+                    created_at: "2026-06-23T10:00:00.000Z",
+                }) + "\n",
+                "utf8",
+            );
+        };
+
+        it("plans a create, not a resume, when the mapped target story is gone", async () => {
+            const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
+            const manifestRoot = path.join(tempDir, ".sb-mig");
+
+            await writeStaleLedger(manifestRoot);
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                    manifestRoot,
+                    yes: true,
+                },
+            } as any);
+
+            const lines = planGateLines();
+
+            expect(lines).toContain(
+                "  2 items (1 folder) -> space target-space (2 create, 0 adopt existing, 0 resume from ledger)",
+            );
+            expect(lines).toContain(
+                "    1 ledger mapping no longer resolves in space target-space and will be discarded.",
+            );
+            // And the plan told the truth: both shells really were created.
+            expect(mocks.createStory).toHaveBeenCalledTimes(2);
+
+            await rm(tempDir, { recursive: true, force: true });
+        });
+
+        it("plans an adoption when another story now holds the mapped target path", async () => {
+            stdin.isTTY = true;
+            mocks.askYesNo.mockResolvedValue(false);
+
+            const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
+            const manifestRoot = path.join(tempDir, ".sb-mig");
+            const getStoryBySlug = mocks.getStoryBySlug.getMockImplementation();
+
+            await writeStaleLedger(manifestRoot);
+
+            mocks.getStoryBySlug.mockImplementation(
+                (slug: string, options: any) => {
+                    if (slug === "imported/blog/post-1") {
+                        return Promise.resolve({
+                            story: {
+                                id: 7777,
+                                slug: "post-1",
+                                full_slug: "imported/blog/post-1",
+                                uuid: "other-target-post-uuid",
+                            },
+                        });
+                    }
+
+                    return getStoryBySlug!(slug, options);
+                },
+            );
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                    manifestRoot,
+                },
+            } as any);
+
+            const lines = planGateLines();
+
+            expect(lines).toContain(
+                "  2 items (1 folder) -> space target-space (1 create, 1 adopt existing, 0 resume from ledger)",
+            );
+            expect(lines).toContain(
+                "    1 ledger mapping no longer resolves in space target-space and will be discarded.",
+            );
+            expect(mocks.createStory).not.toHaveBeenCalled();
+
+            await rm(tempDir, { recursive: true, force: true });
+        });
+
+        it("names the stories and field paths that will break before asking", async () => {
+            stdin.isTTY = true;
+            mocks.askYesNo.mockResolvedValue(false);
+            mocks.getAllStories.mockResolvedValue([
+                {
+                    story: {
+                        id: 2,
+                        name: "Post 1",
+                        slug: "post-1",
+                        full_slug: "blog/post-1",
+                        is_folder: false,
+                        parent_id: 1,
+                        uuid: "source-post-uuid",
+                        content: {
+                            component: "page",
+                            cta: {
+                                linktype: "story",
+                                id: 999,
+                            },
+                        },
+                    },
+                },
+            ]);
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                },
+            } as any);
+
+            const lines = planGateLines();
+            const listingIndex = lines.indexOf("    WILL BREAK, by story:");
+
+            expect(listingIndex).toBeGreaterThan(-1);
+            expect(lines[listingIndex - 1]).toContain(
+                "1 leave your selection and WILL BREAK",
+            );
+            expect(lines[listingIndex + 1]).toBe("      blog/post-1");
+            expect(lines[listingIndex + 2]).toContain("-> #999");
+            expect(lines[listingIndex + 2].trim()).toMatch(/^content\.cta/);
+
+            // The detail is on screen before the operator is asked anything.
+            const listingOrder = (
+                Logger.log as unknown as ReturnType<typeof vi.fn>
+            ).mock.invocationCallOrder[listingIndex];
+
+            expect(mocks.askYesNo).toHaveBeenCalledTimes(1);
+            expect(listingOrder).toBeLessThan(
+                mocks.askYesNo.mock.invocationCallOrder[0],
+            );
+            expect(mocks.createStory).not.toHaveBeenCalled();
         });
     });
 

--- a/__tests__/cli/copy-dry-run.test.ts
+++ b/__tests__/cli/copy-dry-run.test.ts
@@ -365,6 +365,58 @@ describe("copy stories dry-run", () => {
         await rm(tempDir, { recursive: true, force: true });
     });
 
+    it("scans only planned stories in children mode, never the excluded root", async () => {
+        const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
+        const outputPath = path.join(tempDir, "plans", "copy-plan.json");
+
+        await copyCommand({
+            input: ["copy", "stories"],
+            flags: {
+                from: "source-space",
+                to: "target-space",
+                source: "blog",
+                mode: "children",
+                destination: "imported",
+                dryRun: true,
+                outputPath,
+            },
+        } as any);
+
+        const report = JSON.parse(await readFile(outputPath, "utf8"));
+
+        expect(report.items).toMatchObject([
+            {
+                type: "story",
+                sourceFullSlug: "blog/post-1",
+                targetFullSlug: "imported/post-1",
+            },
+        ]);
+        // The root folder `blog` is fetched but not copied. Its own cta -> post-1
+        // reference must not be scanned: it would inflate the relink count for
+        // a story this run never writes.
+        expect(
+            report.graph.storyReferences.map(
+                (reference: any) => reference.sourceStoryFullSlug,
+            ),
+        ).toEqual(["blog/post-1", "blog/post-1"]);
+        expect(report.graph.storyReferences).toMatchObject([
+            { path: "parent_id", status: "will_relink" },
+            {
+                path: "content.body.content[0].attrs.uuid",
+                referencedStoryUuid: "source-blog-uuid",
+                status: "will_break",
+            },
+        ]);
+        expect(report.summary).toMatchObject({
+            storyReferences: 2,
+            storyReferencesWillRelink: 1,
+            storyReferencesWillBreak: 1,
+            storyReferencesExternalKept: 0,
+        });
+
+        await rm(tempDir, { recursive: true, force: true });
+    });
+
     it("flags source components missing from the target space during story dry-run", async () => {
         const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
         const outputPath = path.join(tempDir, "plans", "copy-plan.json");

--- a/__tests__/cli/copy-dry-run.test.ts
+++ b/__tests__/cli/copy-dry-run.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
     getStoryById: vi.fn(),
@@ -22,6 +22,11 @@ const mocks = vi.hoisted(() => ({
     createTree: vi.fn(),
     traverseAndCreate: vi.fn(),
     sbApiGet: vi.fn(),
+    askYesNo: vi.fn(),
+}));
+
+vi.mock("../../src/cli/helpers.js", () => ({
+    askYesNo: mocks.askYesNo,
 }));
 
 vi.mock("../../src/cli/api-config.js", () => ({
@@ -908,6 +913,187 @@ describe("copy stories dry-run", () => {
         await rm(tempDir, { recursive: true, force: true });
     });
 
+    describe("plan gate", () => {
+        const stdin = process.stdin as any;
+        const originalIsTTY = stdin.isTTY;
+        const originalExitCode = process.exitCode;
+
+        afterEach(() => {
+            stdin.isTTY = originalIsTTY;
+            process.exitCode = originalExitCode;
+        });
+
+        it("refuses to write without --yes when no terminal can answer", async () => {
+            stdin.isTTY = false;
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                },
+            } as any);
+
+            expect(mocks.askYesNo).not.toHaveBeenCalled();
+            expect(mocks.createStory).not.toHaveBeenCalled();
+            expect(mocks.updateStory).not.toHaveBeenCalled();
+            expect(process.exitCode).toBe(1);
+        });
+
+        it("asks Continue? on a terminal and stops on anything but yes", async () => {
+            stdin.isTTY = true;
+            mocks.askYesNo.mockResolvedValue(false);
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                },
+            } as any);
+
+            expect(mocks.askYesNo).toHaveBeenCalledWith("Continue? [y/N]");
+            expect(mocks.createStory).not.toHaveBeenCalled();
+            expect(process.exitCode).toBe(originalExitCode);
+        });
+
+        it("writes after an explicit yes on a terminal", async () => {
+            stdin.isTTY = true;
+            mocks.askYesNo.mockResolvedValue(true);
+            const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                    manifestRoot: path.join(tempDir, ".sb-mig"),
+                },
+            } as any);
+
+            expect(mocks.askYesNo).toHaveBeenCalledTimes(1);
+            expect(mocks.createStory).toHaveBeenCalledTimes(2);
+
+            await rm(tempDir, { recursive: true, force: true });
+        });
+
+        it("scans references and checks target paths before the gate in apply mode", async () => {
+            stdin.isTTY = false;
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                },
+            } as any);
+
+            // Scanner ran (component schemas fetched) and every planned
+            // target path was checked for adoption, all before any write.
+            expect(mocks.getAllComponents).toHaveBeenCalledWith(
+                expect.objectContaining({ spaceId: "source-space" }),
+            );
+            expect(mocks.getStoryBySlug).toHaveBeenCalledWith(
+                "imported/blog/post-1",
+                expect.objectContaining({ spaceId: "target-space" }),
+            );
+            expect(mocks.createStory).not.toHaveBeenCalled();
+        });
+
+        it("moves the existing ledger aside with --fresh and starts empty", async () => {
+            const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
+            const manifestRoot = path.join(tempDir, ".sb-mig");
+            const manifestDirectory = path.join(
+                manifestRoot,
+                "copy",
+                "source-space",
+                "target-space",
+            );
+            const staleEntry = {
+                type: "story",
+                source_space_id: "source-space",
+                target_space_id: "target-space",
+                source_id: 2,
+                target_id: 5555,
+                source_uuid: "source-post-uuid",
+                target_uuid: "stale-target-post-uuid",
+                source_full_slug: "blog/post-1",
+                target_full_slug: "imported/blog/post-1",
+                action: "created",
+                created_at: "2026-06-23T10:00:00.000Z",
+            };
+
+            await mkdir(manifestDirectory, { recursive: true });
+            await writeFile(
+                path.join(manifestDirectory, "manifest.jsonl"),
+                JSON.stringify(staleEntry) + "\n",
+                "utf8",
+            );
+            await writeFile(
+                path.join(manifestDirectory, "stories.manifest.jsonl"),
+                JSON.stringify(staleEntry) + "\n",
+                "utf8",
+            );
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                    manifestRoot,
+                    fresh: true,
+                    yes: true,
+                },
+            } as any);
+
+            // The stale mapping was not reused: both shells were created anew.
+            expect(mocks.createStory).toHaveBeenCalledTimes(2);
+            expect(mocks.getStoryById).not.toHaveBeenCalledWith(
+                "5555",
+                expect.anything(),
+            );
+
+            const { readdir } = await import("fs/promises");
+            const files = (await readdir(manifestDirectory)).sort();
+
+            expect(
+                files.filter((file) => /^manifest\.jsonl\..+\.bak$/.test(file)),
+            ).toHaveLength(1);
+            expect(
+                files.filter((file) =>
+                    /^stories\.manifest\.jsonl\..+\.bak$/.test(file),
+                ),
+            ).toHaveLength(1);
+
+            const combined = (
+                await readFile(
+                    path.join(manifestDirectory, "manifest.jsonl"),
+                    "utf8",
+                )
+            )
+                .trim()
+                .split("\n")
+                .map((line) => JSON.parse(line));
+
+            expect(combined.every((entry) => entry.target_id !== 5555)).toBe(
+                true,
+            );
+            expect(combined.map((entry) => entry.source_id)).toEqual([1, 2]);
+
+            await rm(tempDir, { recursive: true, force: true });
+        });
+    });
+
     it("copies selected stories and writes story manifests", async () => {
         const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
         const manifestRoot = path.join(tempDir, ".sb-mig");
@@ -944,6 +1130,7 @@ describe("copy stories dry-run", () => {
                 source: "blog",
                 destination: "imported",
                 manifestRoot,
+                yes: true,
             },
         } as any);
 
@@ -1144,6 +1331,7 @@ describe("copy stories dry-run", () => {
                 source: "plain",
                 destination: "imported",
                 manifestRoot,
+                yes: true,
             },
         } as any);
 
@@ -1244,6 +1432,7 @@ describe("copy stories dry-run", () => {
                 destination: "imported",
                 publicationLanguages: "default",
                 manifestRoot,
+                yes: true,
             },
         } as any);
 
@@ -1340,6 +1529,7 @@ describe("copy stories dry-run", () => {
                 destination: "imported",
                 publicationMode: "save-only",
                 manifestRoot,
+                yes: true,
             },
         } as any);
 
@@ -1434,6 +1624,7 @@ describe("copy stories dry-run", () => {
                 destination: "imported",
                 publicationLanguages: "default",
                 manifestRoot,
+                yes: true,
             },
         } as any);
 
@@ -1507,6 +1698,7 @@ describe("copy stories dry-run", () => {
                     source: "blog",
                     destination: "imported",
                     manifestRoot,
+                    yes: true,
                 },
             } as any),
         ).rejects.toThrow(
@@ -1540,6 +1732,7 @@ describe("copy stories dry-run", () => {
                     source: "blog",
                     destination: "imported",
                     manifestRoot,
+                    yes: true,
                 },
             } as any),
         ).rejects.toThrow(
@@ -1620,6 +1813,7 @@ describe("copy stories dry-run", () => {
                 source: "blog",
                 destination: "imported",
                 manifestRoot,
+                yes: true,
             },
         } as any);
 
@@ -1716,6 +1910,7 @@ describe("copy stories dry-run", () => {
                 source: "blog",
                 destination: "imported",
                 manifestRoot,
+                yes: true,
             },
         } as any);
 
@@ -1789,6 +1984,7 @@ describe("copy stories dry-run", () => {
                 withAssets: true,
                 manifestRoot,
                 outputPath,
+                yes: true,
             },
         } as any);
 

--- a/__tests__/cli/help-output.test.ts
+++ b/__tests__/cli/help-output.test.ts
@@ -120,6 +120,9 @@ describe("CLI help output", () => {
         expect(copyHelp).toContain("--mode");
         expect(copyHelp).toContain("--all");
         expect(copyHelp).toContain("--dry-run");
+        expect(copyHelp).toContain("--yes");
+        expect(copyHelp).toContain("--fresh");
+        expect(copyHelp).toContain("PLAN block");
         expect(copyHelp).toContain("--outputPath");
         expect(copyHelp).toContain("folder/*");
         expect(copyHelp).toContain("durable manifests");

--- a/docs/copy-command-spec.md
+++ b/docs/copy-command-spec.md
@@ -334,8 +334,6 @@ Known fields to rewrite:
 | `options` with `source: "internal_stories"` | story ids  | Replace each source id with target id            |
 | nested `bloks`                              | varies     | Recursively inspect nested components            |
 | richtext embedded bloks                     | varies     | Recursively inspect embedded component content   |
-| `alternates[].id`                           | story id   | Replace source id with target id                 |
-| `alternates[].parent_id`                    | story id   | Replace source parent id with target parent id   |
 | `parent_id`                                 | story id   | Replace source parent id with target parent id   |
 
 If a story reference points to a story outside the selected copy scope, the command must not silently corrupt it. Every scanned story reference in the copy graph (`graph.storyReferences[].status`) is classified against the copy plan **and** the ledger:

--- a/docs/copy-command-spec.md
+++ b/docs/copy-command-spec.md
@@ -338,11 +338,24 @@ Known fields to rewrite:
 | `alternates[].parent_id`                    | story id   | Replace source parent id with target parent id   |
 | `parent_id`                                 | story id   | Replace source parent id with target parent id   |
 
-If a story reference points to a story outside the selected copy scope, the command must not silently corrupt it. The copy report should classify it:
+If a story reference points to a story outside the selected copy scope, the command must not silently corrupt it. Every scanned story reference in the copy graph (`graph.storyReferences[].status`) is classified against the copy plan **and** the ledger:
 
-- `preserved_external_reference`
-- `unresolved_story_reference`
-- `skipped_reference_rewrite`
+| Status          | Meaning                                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `unclassified`  | Emitted by the scanner, which sees one story at a time and cannot know the plan. Replaced before the graph is reported. |
+| `will_relink`   | The referenced story is inside the selection (its mapping exists by phase 2) or is already in the loaded ledger.        |
+| `will_break`    | The referenced story is outside the selection and not in the ledger; in a cross-space copy this reference dangles.      |
+| `external_kept` | Same-space copy, where continuing to point at the original story is correct.                                            |
+| `unresolved`    | Reference policy `fail`: the reference cannot be handled.                                                               |
+| `unsupported`   | The reference shape is not rewritable.                                                                                  |
+
+Notes:
+
+- `parent_id` is resolved by the copy plan itself — phase 1 creates every shell under its planned parent, and the top of the selection lands under the destination — so it is always `will_relink` and never reported as a break.
+- `parent_id: 0` is Storyblok's "lives at the space root" sentinel, not a story id, and is not recorded as a reference at all.
+- When `will_break > 0` the dry-run prints a loud report naming each holding story and field path, and the graph carries a `broken_story_reference` warning per story.
+
+The dry-run summary exposes the same accounting as `storyReferencesWillRelink`, `storyReferencesWillBreak`, `storyReferencesExternalKept` and `storyReferencesUnresolved`.
 
 Potential policies:
 

--- a/src/api/copy/index.ts
+++ b/src/api/copy/index.ts
@@ -1,5 +1,6 @@
 export * from "./graph.js";
 export * from "./manifest.js";
+export * from "./plan-gate.js";
 export * from "./reference-classifier.js";
 export * from "./reference-scanner.js";
 export * from "./reference-rewriter.js";

--- a/src/api/copy/index.ts
+++ b/src/api/copy/index.ts
@@ -1,5 +1,6 @@
 export * from "./graph.js";
 export * from "./manifest.js";
+export * from "./reference-classifier.js";
 export * from "./reference-scanner.js";
 export * from "./reference-rewriter.js";
 export * from "./assets.js";

--- a/src/api/copy/manifest.ts
+++ b/src/api/copy/manifest.ts
@@ -39,6 +39,39 @@ export const getDefaultCopyManifestPaths = ({
     };
 };
 
+/**
+ * Moves every existing manifest file of a copy pair aside so the next run
+ * starts with an empty ledger. Nothing is deleted: each file is renamed with
+ * a timestamp suffix next to the original. Returns the archived paths.
+ */
+export const archiveCopyManifests = async (
+    paths: CopyManifestPaths,
+    now: Date = new Date(),
+): Promise<string[]> => {
+    const suffix = now.toISOString().replace(/[:.]/g, "-");
+    const archived: string[] = [];
+
+    for (const filePath of [
+        paths.combined,
+        paths.stories,
+        paths.assets,
+        paths.assetFolders,
+    ]) {
+        const archivePath = `${filePath}.${suffix}.bak`;
+
+        try {
+            await fs.rename(filePath, archivePath);
+            archived.push(archivePath);
+        } catch (error: any) {
+            if (error?.code !== "ENOENT") {
+                throw error;
+            }
+        }
+    }
+
+    return archived;
+};
+
 export const createEmptyCopyMaps = (): CopyMaps => ({
     storyIds: new Map(),
     storyUuids: new Map(),

--- a/src/api/copy/plan-gate.ts
+++ b/src/api/copy/plan-gate.ts
@@ -1,0 +1,199 @@
+import type { CopyGraph, CopyMaps } from "./types.js";
+
+import { countStoryReferenceStatuses } from "./reference-classifier.js";
+
+/**
+ * Everything a `copy stories` apply run knows before its first write, in one
+ * place. Built from the plan, the target conflict check, the loaded ledger and
+ * the reference scan so the PLAN block can be rendered and tested without any
+ * API access.
+ */
+export type CopyPlanGatePlanItem = {
+    type: "folder" | "story";
+    sourceId?: number;
+    sourceFullSlug: string;
+    targetFullSlug: string;
+};
+
+export type CopyPlanGateLedger = {
+    /** Absolute path of the combined manifest the run reads back. */
+    path: string;
+    /** Entries found on disk, whether or not they are used. */
+    entries: number;
+    /** `--fresh`: the entries above are ignored and the run starts empty. */
+    ignored: boolean;
+};
+
+export type CopyPlanGateSummary = {
+    sourceSpaceId: string;
+    targetSpaceId: string;
+    sameSpace: boolean;
+    stories: {
+        total: number;
+        folders: number;
+        /** No ledger mapping and no existing target path: a new shell. */
+        create: number;
+        /** Ledger already maps the source story: the mapped target is reused. */
+        resume: number;
+        /**
+         * No ledger mapping but the target path already exists: the run adopts
+         * it (`matched_by_target_key`) and UPDATES it in place.
+         */
+        adopt: number;
+    };
+    ledger: CopyPlanGateLedger;
+    references: {
+        scanned: boolean;
+        total: number;
+        willRelink: number;
+        willBreak: number;
+        externalKept: number;
+    };
+    assets?: {
+        toCopy: number;
+        mapped: number;
+    };
+};
+
+export const buildCopyPlanGateSummary = ({
+    sourceSpaceId,
+    targetSpaceId,
+    plan,
+    conflictTargetFullSlugs,
+    copyMaps,
+    ledger,
+    graph,
+    withAssets,
+}: {
+    sourceSpaceId: string;
+    targetSpaceId: string;
+    plan: CopyPlanGatePlanItem[];
+    conflictTargetFullSlugs: Iterable<string>;
+    copyMaps: CopyMaps;
+    ledger: CopyPlanGateLedger;
+    graph?: CopyGraph;
+    withAssets: boolean;
+}): CopyPlanGateSummary => {
+    const conflicts = new Set(conflictTargetFullSlugs);
+    let create = 0;
+    let resume = 0;
+    let adopt = 0;
+
+    for (const item of plan) {
+        if (
+            item.sourceId !== undefined &&
+            copyMaps.storyIds.has(item.sourceId)
+        ) {
+            resume += 1;
+        } else if (conflicts.has(item.targetFullSlug)) {
+            adopt += 1;
+        } else {
+            create += 1;
+        }
+    }
+
+    const referenceCounts = countStoryReferenceStatuses(
+        graph?.storyReferences ?? [],
+    );
+
+    return {
+        sourceSpaceId,
+        targetSpaceId,
+        sameSpace: sourceSpaceId === targetSpaceId,
+        stories: {
+            total: plan.length,
+            folders: plan.filter((item) => item.type === "folder").length,
+            create,
+            resume,
+            adopt,
+        },
+        ledger,
+        references: {
+            scanned: graph !== undefined,
+            total: graph?.storyReferences.length ?? 0,
+            willRelink: referenceCounts.willRelink,
+            willBreak: referenceCounts.willBreak,
+            externalKept: referenceCounts.externalKept,
+        },
+        ...(withAssets && graph
+            ? {
+                  assets: {
+                      toCopy: graph.assets.filter(
+                          (asset) => asset.action === "create",
+                      ).length,
+                      mapped: graph.assets.filter(
+                          (asset) => asset.action === "match",
+                      ).length,
+                  },
+              }
+            : {}),
+    };
+};
+
+const plural = (count: number, singular: string, pluralForm: string) =>
+    count === 1 ? singular : pluralForm;
+
+/**
+ * Renders the PLAN block printed before the confirmation gate. Every line is
+ * a fact the run already knows; nothing here is a promise about the future
+ * beyond what the classifier and the target check established.
+ */
+export const formatCopyPlanGate = (summary: CopyPlanGateSummary): string[] => {
+    const { stories, ledger, references, assets } = summary;
+    const storyParts = [
+        `${stories.create} create`,
+        `${stories.adopt} adopt existing`,
+        `${stories.resume} resume from ledger`,
+    ];
+    const lines = [
+        "PLAN",
+        `  ${stories.total} ${plural(stories.total, "item", "items")} (${stories.folders} ${plural(stories.folders, "folder", "folders")}) -> space ${summary.targetSpaceId} (${storyParts.join(", ")})`,
+    ];
+
+    if (stories.adopt > 0) {
+        lines.push(
+            `    ${stories.adopt} existing target ${plural(stories.adopt, "path", "paths")} will be adopted and UPDATED in place.`,
+        );
+    }
+
+    if (ledger.ignored) {
+        lines.push(
+            `  ledger: ${ledger.entries} ${plural(ledger.entries, "entry", "entries")} at ${ledger.path} IGNORED (--fresh; starting empty)`,
+        );
+    } else if (ledger.entries > 0) {
+        lines.push(
+            `  ledger: ${ledger.entries} ${plural(ledger.entries, "entry", "entries")} loaded from ${ledger.path} (resuming; use --fresh to ignore)`,
+        );
+    } else {
+        lines.push(`  ledger: none at ${ledger.path} (starting empty)`);
+    }
+
+    if (!references.scanned) {
+        lines.push("  references: not scanned");
+    } else {
+        const referenceParts = [`${references.willRelink} will relink`];
+
+        if (summary.sameSpace) {
+            referenceParts.push(
+                `${references.externalKept} outside the selection kept (same space)`,
+            );
+        }
+
+        referenceParts.push(
+            references.willBreak > 0
+                ? `${references.willBreak} leave your selection and WILL BREAK`
+                : "0 will break",
+        );
+        lines.push(`  references: ${referenceParts.join(", ")}`);
+    }
+
+    if (assets) {
+        lines.push(
+            `  assets: ${assets.toCopy} will copy, ${assets.mapped} already mapped`,
+        );
+    } else {
+        lines.push("  assets: not copied (pass --with-assets)");
+    }
+
+    return lines;
+};

--- a/src/api/copy/plan-gate.ts
+++ b/src/api/copy/plan-gate.ts
@@ -1,6 +1,11 @@
-import type { CopyGraph, CopyMaps } from "./types.js";
+import type { CopyGraph } from "./types.js";
 
-import { countStoryReferenceStatuses } from "./reference-classifier.js";
+import {
+    countStoryReferenceStatuses,
+    describeBrokenStoryReferenceTarget,
+    groupBrokenStoryReferences,
+    type CopyBrokenStoryReferenceGroup,
+} from "./reference-classifier.js";
 
 /**
  * Everything a `copy stories` apply run knows before its first write, in one
@@ -10,9 +15,16 @@ import { countStoryReferenceStatuses } from "./reference-classifier.js";
  */
 export type CopyPlanGatePlanItem = {
     type: "folder" | "story";
-    sourceId?: number;
     sourceFullSlug: string;
     targetFullSlug: string;
+    /**
+     * Target story id the ledger maps this source story to, if any. A mapping
+     * only counts as a resume when the mapped story is the one actually living
+     * at `targetFullSlug` — see `existingTargetStoryId`.
+     */
+    ledgerTargetStoryId?: number;
+    /** Id of the story that already occupies `targetFullSlug` in the target. */
+    existingTargetStoryId?: number;
 };
 
 export type CopyPlanGateLedger = {
@@ -31,15 +43,21 @@ export type CopyPlanGateSummary = {
     stories: {
         total: number;
         folders: number;
-        /** No ledger mapping and no existing target path: a new shell. */
+        /** No usable ledger mapping and no existing target path: a new shell. */
         create: number;
-        /** Ledger already maps the source story: the mapped target is reused. */
+        /** The ledger maps the source story to the story at the target path. */
         resume: number;
         /**
-         * No ledger mapping but the target path already exists: the run adopts
-         * it (`matched_by_target_key`) and UPDATES it in place.
+         * No usable ledger mapping but the target path already exists: the run
+         * adopts it (`matched_by_target_key`) and UPDATES it in place.
          */
         adopt: number;
+        /**
+         * Ledger mappings that no longer resolve in the target space (the
+         * mapped story was deleted, moved or replaced). They are counted as
+         * create/adopt above, exactly as the run will treat them.
+         */
+        staleLedger: number;
     };
     ledger: CopyPlanGateLedger;
     references: {
@@ -48,6 +66,8 @@ export type CopyPlanGateSummary = {
         willRelink: number;
         willBreak: number;
         externalKept: number;
+        /** The will-break references grouped by the story that holds them. */
+        breaking: CopyBrokenStoryReferenceGroup[];
     };
     assets?: {
         toCopy: number;
@@ -55,12 +75,13 @@ export type CopyPlanGateSummary = {
     };
 };
 
+/** How many holding stories the PLAN block names before it summarises the rest. */
+const MAX_LISTED_BREAK_GROUPS = 20;
+
 export const buildCopyPlanGateSummary = ({
     sourceSpaceId,
     targetSpaceId,
     plan,
-    conflictTargetFullSlugs,
-    copyMaps,
     ledger,
     graph,
     withAssets,
@@ -68,24 +89,28 @@ export const buildCopyPlanGateSummary = ({
     sourceSpaceId: string;
     targetSpaceId: string;
     plan: CopyPlanGatePlanItem[];
-    conflictTargetFullSlugs: Iterable<string>;
-    copyMaps: CopyMaps;
     ledger: CopyPlanGateLedger;
     graph?: CopyGraph;
     withAssets: boolean;
 }): CopyPlanGateSummary => {
-    const conflicts = new Set(conflictTargetFullSlugs);
     let create = 0;
     let resume = 0;
     let adopt = 0;
+    let staleLedger = 0;
 
     for (const item of plan) {
-        if (
-            item.sourceId !== undefined &&
-            copyMaps.storyIds.has(item.sourceId)
-        ) {
-            resume += 1;
-        } else if (conflicts.has(item.targetFullSlug)) {
+        if (item.ledgerTargetStoryId !== undefined) {
+            if (item.ledgerTargetStoryId === item.existingTargetStoryId) {
+                resume += 1;
+                continue;
+            }
+
+            // The mapping is on disk but the target no longer backs it, so the
+            // run will discard it and fall through to adoption or creation.
+            staleLedger += 1;
+        }
+
+        if (item.existingTargetStoryId !== undefined) {
             adopt += 1;
         } else {
             create += 1;
@@ -106,6 +131,7 @@ export const buildCopyPlanGateSummary = ({
             create,
             resume,
             adopt,
+            staleLedger,
         },
         ledger,
         references: {
@@ -114,6 +140,7 @@ export const buildCopyPlanGateSummary = ({
             willRelink: referenceCounts.willRelink,
             willBreak: referenceCounts.willBreak,
             externalKept: referenceCounts.externalKept,
+            breaking: groupBrokenStoryReferences(graph?.storyReferences ?? []),
         },
         ...(withAssets && graph
             ? {
@@ -156,6 +183,12 @@ export const formatCopyPlanGate = (summary: CopyPlanGateSummary): string[] => {
         );
     }
 
+    if (stories.staleLedger > 0) {
+        lines.push(
+            `    ${stories.staleLedger} ledger ${plural(stories.staleLedger, "mapping", "mappings")} no longer ${plural(stories.staleLedger, "resolves", "resolve")} in space ${summary.targetSpaceId} and will be discarded.`,
+        );
+    }
+
     if (ledger.ignored) {
         lines.push(
             `  ledger: ${ledger.entries} ${plural(ledger.entries, "entry", "entries")} at ${ledger.path} IGNORED (--fresh; starting empty)`,
@@ -185,6 +218,7 @@ export const formatCopyPlanGate = (summary: CopyPlanGateSummary): string[] => {
                 : "0 will break",
         );
         lines.push(`  references: ${referenceParts.join(", ")}`);
+        lines.push(...formatBreakingReferences(references.breaking));
     }
 
     if (assets) {
@@ -193,6 +227,41 @@ export const formatCopyPlanGate = (summary: CopyPlanGateSummary): string[] => {
         );
     } else {
         lines.push("  assets: not copied (pass --with-assets)");
+    }
+
+    return lines;
+};
+
+/**
+ * The same grouped detail the dry-run prints: a count alone does not tell the
+ * operator which stories are about to lose which fields, and the gate is the
+ * last moment they can act on it.
+ */
+const formatBreakingReferences = (
+    groups: CopyBrokenStoryReferenceGroup[],
+): string[] => {
+    if (groups.length === 0) {
+        return [];
+    }
+
+    const lines = ["    WILL BREAK, by story:"];
+
+    for (const group of groups.slice(0, MAX_LISTED_BREAK_GROUPS)) {
+        lines.push(`      ${group.sourceStoryFullSlug}`);
+
+        for (const reference of group.references) {
+            lines.push(
+                `        ${reference.path} -> ${describeBrokenStoryReferenceTarget(reference)}`,
+            );
+        }
+    }
+
+    const hidden = groups.length - MAX_LISTED_BREAK_GROUPS;
+
+    if (hidden > 0) {
+        lines.push(
+            `      ...and ${hidden} more ${plural(hidden, "story", "stories")} with breaking references; run with --dryRun for the full list.`,
+        );
     }
 
     return lines;

--- a/src/api/copy/reference-classifier.ts
+++ b/src/api/copy/reference-classifier.ts
@@ -1,0 +1,213 @@
+import type {
+    CopyGraphStoryNode,
+    CopyGraphStoryReference,
+    CopyMaps,
+    CopyStoryReferenceStatus,
+} from "./types.js";
+
+/**
+ * The set of source stories a copy run is about to write. Built from the copy
+ * plan, so a reference pointing into it is guaranteed to have a mapping by the
+ * time phase 2 rewrites content.
+ */
+export type CopyReferenceSelection = {
+    storyIds: Set<number>;
+    storyUuids: Set<string>;
+};
+
+export type CopyStoryReferenceStatusCounts = {
+    willRelink: number;
+    willBreak: number;
+    externalKept: number;
+    unresolved: number;
+    unsupported: number;
+    unclassified: number;
+};
+
+export type CopyBrokenStoryReferenceGroup = {
+    sourceStoryFullSlug: string;
+    references: CopyGraphStoryReference[];
+};
+
+/**
+ * `parent_id` is resolved by the copy plan itself: phase 1 creates every shell
+ * under its planned parent, and the top of the selection lands under the
+ * destination. It cannot dangle the way a content reference can, so it is
+ * never reported as a break — even when the source parent is out of scope.
+ */
+const STRUCTURAL_REFERENCE_PATHS = new Set(["parent_id"]);
+
+export const buildCopyReferenceSelection = (
+    stories: CopyGraphStoryNode[],
+): CopyReferenceSelection => {
+    const storyIds = new Set<number>();
+    const storyUuids = new Set<string>();
+
+    for (const story of stories) {
+        // Plan items whose source story could not be resolved carry sourceId 0.
+        if (Number.isFinite(story.sourceId) && story.sourceId > 0) {
+            storyIds.add(story.sourceId);
+        }
+
+        if (story.sourceUuid) {
+            storyUuids.add(story.sourceUuid);
+        }
+    }
+
+    return { storyIds, storyUuids };
+};
+
+export const createEmptyCopyReferenceSelection =
+    (): CopyReferenceSelection => ({
+        storyIds: new Set(),
+        storyUuids: new Set(),
+    });
+
+const isInSelection = (
+    reference: CopyGraphStoryReference,
+    selection: CopyReferenceSelection,
+): boolean =>
+    (reference.referencedStoryId !== undefined &&
+        selection.storyIds.has(reference.referencedStoryId)) ||
+    (reference.referencedStoryUuid !== undefined &&
+        selection.storyUuids.has(reference.referencedStoryUuid));
+
+const isInLedger = (
+    reference: CopyGraphStoryReference,
+    copyMaps: CopyMaps,
+): boolean =>
+    (reference.referencedStoryId !== undefined &&
+        copyMaps.storyIds.has(reference.referencedStoryId)) ||
+    (reference.referencedStoryUuid !== undefined &&
+        copyMaps.storyUuids.has(reference.referencedStoryUuid));
+
+export const classifyStoryReferenceStatus = ({
+    reference,
+    selection,
+    copyMaps,
+    sameSpace,
+}: {
+    reference: CopyGraphStoryReference;
+    selection: CopyReferenceSelection;
+    copyMaps: CopyMaps;
+    sameSpace: boolean;
+}): CopyStoryReferenceStatus => {
+    // The scanner already decided these; the copy plan cannot improve on them.
+    if (
+        reference.status === "unresolved" ||
+        reference.status === "unsupported"
+    ) {
+        return reference.status;
+    }
+
+    if (STRUCTURAL_REFERENCE_PATHS.has(reference.path)) {
+        return "will_relink";
+    }
+
+    if (
+        isInSelection(reference, selection) ||
+        isInLedger(reference, copyMaps)
+    ) {
+        return "will_relink";
+    }
+
+    return sameSpace ? "external_kept" : "will_break";
+};
+
+export const classifyStoryReferences = ({
+    storyReferences,
+    selection,
+    copyMaps,
+    sameSpace,
+}: {
+    storyReferences: CopyGraphStoryReference[];
+    selection: CopyReferenceSelection;
+    copyMaps: CopyMaps;
+    sameSpace: boolean;
+}): CopyGraphStoryReference[] =>
+    storyReferences.map((reference) => ({
+        ...reference,
+        status: classifyStoryReferenceStatus({
+            reference,
+            selection,
+            copyMaps,
+            sameSpace,
+        }),
+    }));
+
+export const countStoryReferenceStatuses = (
+    storyReferences: CopyGraphStoryReference[],
+): CopyStoryReferenceStatusCounts => {
+    const counts: CopyStoryReferenceStatusCounts = {
+        willRelink: 0,
+        willBreak: 0,
+        externalKept: 0,
+        unresolved: 0,
+        unsupported: 0,
+        unclassified: 0,
+    };
+
+    for (const reference of storyReferences) {
+        switch (reference.status) {
+            case "will_relink":
+                counts.willRelink += 1;
+                break;
+            case "will_break":
+                counts.willBreak += 1;
+                break;
+            case "external_kept":
+                counts.externalKept += 1;
+                break;
+            case "unresolved":
+                counts.unresolved += 1;
+                break;
+            case "unsupported":
+                counts.unsupported += 1;
+                break;
+            default:
+                counts.unclassified += 1;
+                break;
+        }
+    }
+
+    return counts;
+};
+
+/**
+ * Groups the references that will dangle by the story that holds them, so the
+ * report can name a story once and list its offending field paths under it.
+ */
+export const groupBrokenStoryReferences = (
+    storyReferences: CopyGraphStoryReference[],
+): CopyBrokenStoryReferenceGroup[] => {
+    const groups = new Map<string, CopyBrokenStoryReferenceGroup>();
+
+    for (const reference of storyReferences) {
+        if (reference.status !== "will_break") {
+            continue;
+        }
+
+        const sourceStoryFullSlug =
+            reference.sourceStoryFullSlug ??
+            (reference.sourceStoryId !== undefined
+                ? `#${reference.sourceStoryId}`
+                : "<unknown story>");
+        const group = groups.get(sourceStoryFullSlug) ?? {
+            sourceStoryFullSlug,
+            references: [],
+        };
+
+        group.references.push(reference);
+        groups.set(sourceStoryFullSlug, group);
+    }
+
+    return Array.from(groups.values());
+};
+
+export const describeBrokenStoryReferenceTarget = (
+    reference: CopyGraphStoryReference,
+): string =>
+    reference.referencedStoryUuid ??
+    (reference.referencedStoryId !== undefined
+        ? `#${reference.referencedStoryId}`
+        : "<unknown target>");

--- a/src/api/copy/reference-scanner.ts
+++ b/src/api/copy/reference-scanner.ts
@@ -15,7 +15,6 @@ type StoryLike = {
     uuid?: string;
     full_slug?: string;
     parent_id?: number | null;
-    alternates?: Array<{ id?: number; parent_id?: number | null }>;
     content?: Record<string, unknown>;
 };
 
@@ -150,21 +149,9 @@ const scanStoryMetadata = (story: StoryLike, state: ScannerState) => {
         });
     }
 
-    story.alternates?.forEach((alternate, index) => {
-        if (typeof alternate.id === "number") {
-            addStoryReference(state, {
-                path: `alternates[${index}].id`,
-                referencedStoryId: alternate.id,
-            });
-        }
-
-        if (typeof alternate.parent_id === "number") {
-            addStoryReference(state, {
-                path: `alternates[${index}].parent_id`,
-                referencedStoryId: alternate.parent_id,
-            });
-        }
-    });
+    // `alternates` is read-only API metadata that the copy payload strips
+    // before writing, so it is never rewritten and never dangles. Scanning it
+    // would report references that no copy phase acts on.
 };
 
 const scanComponentNode = (

--- a/src/api/copy/reference-scanner.ts
+++ b/src/api/copy/reference-scanner.ts
@@ -141,7 +141,9 @@ export const scanStoriesReferences = ({
 };
 
 const scanStoryMetadata = (story: StoryLike, state: ScannerState) => {
-    if (typeof story.parent_id === "number") {
+    // parent_id 0 is Storyblok's "lives at the space root" sentinel, not a
+    // story id. Recording it inflated every reference count with a phantom.
+    if (typeof story.parent_id === "number" && story.parent_id !== 0) {
         addStoryReference(state, {
             path: "parent_id",
             referencedStoryId: story.parent_id,
@@ -503,9 +505,12 @@ const addStoryReference = (
         type: "story_reference",
         ...state.context,
         ...reference,
+        // The scanner sees one story at a time, so it cannot know whether the
+        // referenced story is inside the copy plan. The classifier decides
+        // that; see classifyStoryReferences in ./reference-classifier.ts.
         status:
             state.options.referencePolicy === "preserve"
-                ? "preserved_external"
+                ? "unclassified"
                 : "unresolved",
     });
 };

--- a/src/api/copy/types.ts
+++ b/src/api/copy/types.ts
@@ -121,6 +121,28 @@ export type CopyGraphAssetFolderNode = {
     action: CopyGraphAction;
 };
 
+/**
+ * Scope-aware lifecycle of a scanned story reference.
+ *
+ * - `unclassified` — emitted by the scanner, which sees a single story and
+ *   therefore cannot know the copy plan. Replaced by the classifier.
+ * - `will_relink` — the referenced story is inside the selection (its mapping
+ *   will exist by phase 2) or is already in the loaded ledger.
+ * - `will_break` — the referenced story is outside the selection and not in
+ *   the ledger; in a cross-space copy this reference dangles.
+ * - `external_kept` — same-space copy, where pointing at the original story
+ *   remains correct.
+ * - `unresolved` — reference policy `fail`: the reference cannot be handled.
+ * - `unsupported` — the reference shape is not rewritable.
+ */
+export type CopyStoryReferenceStatus =
+    | "unclassified"
+    | "will_relink"
+    | "will_break"
+    | "external_kept"
+    | "unresolved"
+    | "unsupported";
+
 export type CopyGraphStoryReference = {
     type: "story_reference";
     sourceStoryId?: number;
@@ -129,7 +151,7 @@ export type CopyGraphStoryReference = {
     referencedStoryId?: number;
     referencedStoryUuid?: string;
     path: string;
-    status: "mapped" | "preserved_external" | "unresolved" | "unsupported";
+    status: CopyStoryReferenceStatus;
 };
 
 export type CopyGraphAssetReference = {

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -248,7 +248,7 @@ export const copyDescription = `
         --referenced-by-stories
                        Select assets referenced by a story/folder scope. Requires --source. [assets only]
         --dry-run       Preview story paths, manifest-mapped references, and likely target conflicts without writing to Storyblok.
-        --yes           Skip the 'Continue? [y/N]' plan gate that copy stories shows before its first write. Required in non-interactive runs (CI). [stories only]
+        --yes           Skip the confirmation gate that copy stories shows after its PLAN block, before its first write. Required in non-interactive runs (CI). [stories only]
         --fresh         Ignore the existing copy ledger for this run; existing manifest files are moved aside with a timestamp suffix, never deleted. [stories only]
         --outputPath    Optional JSON file path for a dry-run copy plan artifact. Only writes locally when passed.
 
@@ -272,7 +272,7 @@ export const copyDescription = `
         mode 'subtree' copies a folder and all descendants. This is the default for folders.
         mode 'children' copies a folder's descendants without the folder root.
         mode 'self' copies only the source story or folder shell.
-        copy stories prints a PLAN block (create/adopt/resume counts, ledger, will-relink/will-break references, assets) and asks 'Continue? [y/N]' before any write; pass --yes to skip the question. Without a terminal and without --yes it refuses to write.
+        copy stories prints a PLAN block (create/adopt/resume counts, ledger, will-relink/will-break references, assets) and asks for confirmation before any write; pass --yes to skip the question. Without a terminal and without --yes it refuses to write.
         copy stories creates or matches target story shells, then fills them with rewritten source content.
         copy stories matches existing targets by manifest first, then target full_slug when safe, so reruns can reuse mapped target stories.
         copy stories rewrites mapped asset and story references after story manifests exist.

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -249,7 +249,7 @@ export const copyDescription = `
                        Select assets referenced by a story/folder scope. Requires --source. [assets only]
         --dry-run       Preview story paths, manifest-mapped references, and likely target conflicts without writing to Storyblok.
         --yes           Skip the confirmation gate that copy stories shows after its PLAN block, before its first write. Required in non-interactive runs (CI). [stories only]
-        --fresh         Ignore the existing copy ledger for this run; existing manifest files are moved aside with a timestamp suffix, never deleted. [stories only]
+        --fresh         Ignore the existing copy ledger for this run; every manifest file of this space pair, the asset and asset-folder ledgers included, is moved aside with a timestamp suffix, never deleted. A later --with-assets run therefore starts without the archived asset mappings too. [stories only]
         --outputPath    Optional JSON file path for a dry-run copy plan artifact. Only writes locally when passed.
 
     LEGACY FLAGS

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -248,6 +248,8 @@ export const copyDescription = `
         --referenced-by-stories
                        Select assets referenced by a story/folder scope. Requires --source. [assets only]
         --dry-run       Preview story paths, manifest-mapped references, and likely target conflicts without writing to Storyblok.
+        --yes           Skip the 'Continue? [y/N]' plan gate that copy stories shows before its first write. Required in non-interactive runs (CI). [stories only]
+        --fresh         Ignore the existing copy ledger for this run; existing manifest files are moved aside with a timestamp suffix, never deleted. [stories only]
         --outputPath    Optional JSON file path for a dry-run copy plan artifact. Only writes locally when passed.
 
     LEGACY FLAGS
@@ -270,6 +272,7 @@ export const copyDescription = `
         mode 'subtree' copies a folder and all descendants. This is the default for folders.
         mode 'children' copies a folder's descendants without the folder root.
         mode 'self' copies only the source story or folder shell.
+        copy stories prints a PLAN block (create/adopt/resume counts, ledger, will-relink/will-break references, assets) and asks 'Continue? [y/N]' before any write; pass --yes to skip the question. Without a terminal and without --yes it refuses to write.
         copy stories creates or matches target story shells, then fills them with rewritten source content.
         copy stories matches existing targets by manifest first, then target full_slug when safe, so reruns can reuse mapped target stories.
         copy stories rewrites mapped asset and story references after story manifests exist.

--- a/src/cli/commands/copy.ts
+++ b/src/cli/commands/copy.ts
@@ -2243,10 +2243,17 @@ const annotateReferencesWithManifestMaps = ({
     graph,
     copyMaps,
     withAssets,
+    classifyStories,
 }: {
     graph: CopyGraph;
     copyMaps: CopyMaps;
     withAssets: boolean;
+    /**
+     * Only a story-copy run rewrites story references, so only it can promise
+     * `will_relink` or warn `will_break`. Asset-only runs leave the scanner's
+     * neutral `unclassified` status in place.
+     */
+    classifyStories: boolean;
 }) => {
     for (const reference of graph.assetReferences) {
         if (hasMappedAssetReference({ ...reference, copyMaps })) {
@@ -2257,6 +2264,10 @@ const annotateReferencesWithManifestMaps = ({
         if (!withAssets && reference.status === "planned") {
             reference.status = "unresolved";
         }
+    }
+
+    if (!classifyStories) {
+        return;
     }
 
     // Story references are classified against the copy plan as well as the
@@ -2328,6 +2339,27 @@ const annotateAssetsWithManifestMaps = ({
     }
 };
 
+/**
+ * Restricts the scan input to the stories the plan will actually write. The
+ * selection fetch can return more than the plan (children mode fetches the
+ * root folder but does not copy it); scanning those would attribute
+ * references to a run that never touches them.
+ */
+const selectPlannedSourceStories = (
+    sourceStories: any[],
+    plan: CopyPlanItem[],
+): any[] => {
+    const plannedFullSlugs = new Set(plan.map((item) => item.sourceFullSlug));
+
+    return sourceStories
+        .map((item) => item?.story)
+        .filter(
+            (story) =>
+                Boolean(story) &&
+                plannedFullSlugs.has(String(story.full_slug ?? "")),
+        );
+};
+
 const buildStoryReferenceDryRunGraph = ({
     sourceSpace,
     targetSpace,
@@ -2360,7 +2392,7 @@ const buildStoryReferenceDryRunGraph = ({
             .map((story) => [String(story.full_slug ?? ""), story] as const),
     );
     const scanResult = scanStoriesReferences({
-        stories: sourceStories.map((item) => item?.story).filter(Boolean),
+        stories: selectPlannedSourceStories(sourceStories, plan),
         schemas,
         options: {
             referencePolicy: "preserve",
@@ -2401,6 +2433,7 @@ const buildStoryReferenceDryRunGraph = ({
         graph,
         copyMaps,
         withAssets: false,
+        classifyStories: true,
     });
 
     return graph;
@@ -2417,6 +2450,7 @@ const buildReferencedAssetsGraph = ({
     sourceAssetFolders,
     schemas,
     copyMaps,
+    classifyStories,
     onScanProgress,
 }: {
     sourceSpace: string;
@@ -2429,6 +2463,7 @@ const buildReferencedAssetsGraph = ({
     sourceAssetFolders: any[];
     schemas: Record<string, any>;
     copyMaps: CopyMaps;
+    classifyStories: boolean;
     onScanProgress?: (progress: {
         scanned: number;
         total: number;
@@ -2436,7 +2471,7 @@ const buildReferencedAssetsGraph = ({
     }) => void;
 }): CopyGraph => {
     const scanResult = scanStoriesReferences({
-        stories: sourceStories.map((item) => item?.story).filter(Boolean),
+        stories: selectPlannedSourceStories(sourceStories, plan),
         schemas,
         options: {
             referencePolicy: "preserve",
@@ -2523,6 +2558,7 @@ const buildReferencedAssetsGraph = ({
         graph,
         copyMaps,
         withAssets: true,
+        classifyStories,
     });
     annotateAssetsWithManifestMaps({
         graph,
@@ -3895,6 +3931,7 @@ export const copyCommand = async (props: CLIOptions) => {
                         sourceAssetFolders,
                         schemas,
                         copyMaps,
+                        classifyStories: true,
                         onScanProgress: logReferenceScanProgress,
                     });
                     Logger.success(
@@ -4147,6 +4184,9 @@ export const copyCommand = async (props: CLIOptions) => {
                     sourceAssetFolders,
                     schemas,
                     copyMaps,
+                    // An asset-only run never rewrites stories, so story
+                    // references stay `unclassified` and never warn.
+                    classifyStories: false,
                     onScanProgress: logReferenceScanProgress,
                 });
                 Logger.success(

--- a/src/cli/commands/copy.ts
+++ b/src/cli/commands/copy.ts
@@ -19,9 +19,14 @@ import {
     appendManifestEntry,
     buildCopyAssetsGraph,
     buildCopyMaps,
+    buildCopyReferenceSelection,
+    classifyStoryReferences,
+    countStoryReferenceStatuses,
     createCopyGraph,
     dedupeManifestFile,
+    describeBrokenStoryReferenceTarget,
     getDefaultCopyManifestPaths,
+    groupBrokenStoryReferences,
     loadManifest,
     normalizeAssetFolderParentId,
     rewriteCopyReferences,
@@ -154,8 +159,9 @@ type CopyDryRunReport = {
         assetsMapped: number;
         assetsToCopy: number;
         storyReferences: number;
-        storyReferencesMapped: number;
-        storyReferencesPreserved: number;
+        storyReferencesWillRelink: number;
+        storyReferencesWillBreak: number;
+        storyReferencesExternalKept: number;
         storyReferencesUnresolved: number;
         conflicts: number;
         warnings: number;
@@ -1404,18 +1410,9 @@ const buildCopyDryRunReport = ({
         graph?.assetReferences.filter(
             (reference) => reference.status === "unresolved",
         ).length ?? 0;
-    const storyReferencesMapped =
-        graph?.storyReferences.filter(
-            (reference) => reference.status === "mapped",
-        ).length ?? 0;
-    const storyReferencesPreserved =
-        graph?.storyReferences.filter(
-            (reference) => reference.status === "preserved_external",
-        ).length ?? 0;
-    const storyReferencesUnresolved =
-        graph?.storyReferences.filter(
-            (reference) => reference.status === "unresolved",
-        ).length ?? 0;
+    const storyReferenceCounts = countStoryReferenceStatuses(
+        graph?.storyReferences ?? [],
+    );
     const assetsMapped =
         graph?.assets.filter((asset) => asset.action === "match").length ?? 0;
     const assetsToCopy =
@@ -1458,9 +1455,10 @@ const buildCopyDryRunReport = ({
             assetsMapped,
             assetsToCopy,
             storyReferences: graphSummary?.storyReferences ?? 0,
-            storyReferencesMapped,
-            storyReferencesPreserved,
-            storyReferencesUnresolved,
+            storyReferencesWillRelink: storyReferenceCounts.willRelink,
+            storyReferencesWillBreak: storyReferenceCounts.willBreak,
+            storyReferencesExternalKept: storyReferenceCounts.externalKept,
+            storyReferencesUnresolved: storyReferenceCounts.unresolved,
             conflicts: conflicts.length,
             warnings: warnings.length + (graphSummary?.warnings ?? 0),
             errors: graphSummary?.errors ?? 0,
@@ -2261,15 +2259,27 @@ const annotateReferencesWithManifestMaps = ({
         }
     }
 
-    for (const reference of graph.storyReferences) {
-        if (
-            (reference.referencedStoryId !== undefined &&
-                copyMaps.storyIds.has(reference.referencedStoryId)) ||
-            (reference.referencedStoryUuid !== undefined &&
-                copyMaps.storyUuids.has(reference.referencedStoryUuid))
-        ) {
-            reference.status = "mapped";
-        }
+    // Story references are classified against the copy plan as well as the
+    // ledger: a reference into the selection relinks once phase 2 runs, one
+    // that points outside it dangles. graph.stories already carries the plan.
+    graph.storyReferences = classifyStoryReferences({
+        storyReferences: graph.storyReferences,
+        selection: buildCopyReferenceSelection(graph.stories),
+        copyMaps,
+        sameSpace: graph.sourceSpaceId === graph.targetSpaceId,
+    });
+
+    for (const group of groupBrokenStoryReferences(graph.storyReferences)) {
+        graph.warnings.push({
+            code: "broken_story_reference",
+            message: `Story '${group.sourceStoryFullSlug}' references ${group.references.length} story/stories outside this copy that are not in the ledger; the copied content will point at nothing.`,
+            path: group.references
+                .map((reference) => reference.path)
+                .join(", "),
+            sourceValue: group.references.map(
+                describeBrokenStoryReferenceTarget,
+            ),
+        });
     }
 };
 
@@ -3614,8 +3624,26 @@ const logDryRunCopyPlan = async ({ report }: { report: CopyDryRunReport }) => {
         }
 
         Logger.warning(
-            `[dry-run] Story refs: ${report.summary.storyReferencesMapped} mapped, ${report.summary.storyReferencesPreserved} preserved, ${report.summary.storyReferencesUnresolved} unresolved.`,
+            `[dry-run] Story refs: ${report.summary.storyReferencesWillRelink} will relink, ${report.summary.storyReferencesWillBreak} will break, ${report.summary.storyReferencesExternalKept} external kept, ${report.summary.storyReferencesUnresolved} unresolved.`,
         );
+
+        if (report.summary.storyReferencesWillBreak > 0) {
+            Logger.error(
+                `[dry-run] ${report.summary.storyReferencesWillBreak} story reference(s) WILL BREAK: they point at stories outside this copy and are not in the ledger, so the copied content will point at nothing.`,
+            );
+
+            for (const group of groupBrokenStoryReferences(
+                report.graph.storyReferences,
+            )) {
+                Logger.error(`[dry-run]   ${group.sourceStoryFullSlug}`);
+
+                for (const reference of group.references) {
+                    Logger.error(
+                        `[dry-run]     ${reference.path} -> ${describeBrokenStoryReferenceTarget(reference)}`,
+                    );
+                }
+            }
+        }
 
         for (const folder of report.graph.assetFolders) {
             Logger.warning(

--- a/src/cli/commands/copy.ts
+++ b/src/cli/commands/copy.ts
@@ -994,14 +994,21 @@ const buildCopyPlan = (
     return plan;
 };
 
+type CopyTargetConflictCheck = {
+    /** Planned paths that already hold a story or folder in the target. */
+    conflicts: CopyPlanItem[];
+    /** Id of the story occupying each of those paths, keyed by target path. */
+    existingTargetStoryIdByFullSlug: Map<string, number>;
+};
+
 const findTargetConflicts = async (
     plan: CopyPlanItem[],
     targetSpace: string,
-): Promise<CopyPlanItem[]> => {
+): Promise<CopyTargetConflictCheck> => {
     let checked = 0;
 
     if (plan.length === 0) {
-        return [];
+        return { conflicts: [], existingTargetStoryIdByFullSlug: new Map() };
     }
 
     Logger.warning(
@@ -1031,19 +1038,48 @@ const findTargetConflicts = async (
                 );
             }
 
-            return existingStory ? item : null;
+            if (!existingStory) {
+                return null;
+            }
+
+            const existingStoryId = existingStory?.story?.id;
+
+            return {
+                item,
+                existingTargetStoryId:
+                    existingStoryId === undefined
+                        ? undefined
+                        : Number(existingStoryId),
+            };
         },
     );
 
-    const conflicts = results.filter(
-        (item): item is CopyPlanItem => item !== null,
+    const found = results.filter(
+        (
+            result,
+        ): result is {
+            item: CopyPlanItem;
+            existingTargetStoryId: number | undefined;
+        } => result !== null,
+    );
+    const conflicts = found.map((result) => result.item);
+    const existingTargetStoryIdByFullSlug = new Map<string, number>(
+        found
+            .filter((result) => result.existingTargetStoryId !== undefined)
+            .map(
+                (result) =>
+                    [
+                        result.item.targetFullSlug,
+                        result.existingTargetStoryId as number,
+                    ] as const,
+            ),
     );
 
     Logger.success(
         `Target conflict check complete. Found ${conflicts.length} existing target path(s).`,
     );
 
-    return conflicts;
+    return { conflicts, existingTargetStoryIdByFullSlug };
 };
 
 const withConflictFlags = (
@@ -4015,7 +4051,10 @@ export const copyCommand = async (props: CLIOptions) => {
             }
 
             if (dryRun) {
-                const conflicts = await findTargetConflicts(plan, targetSpace);
+                const { conflicts } = await findTargetConflicts(
+                    plan,
+                    targetSpace,
+                );
                 Logger.warning(
                     "Checking source components against the target space schema.",
                 );
@@ -4063,7 +4102,8 @@ export const copyCommand = async (props: CLIOptions) => {
                 break;
             }
 
-            const conflicts = await findTargetConflicts(plan, targetSpace);
+            const { existingTargetStoryIdByFullSlug } =
+                await findTargetConflicts(plan, targetSpace);
             const sourceStoryByFullSlug = new Map(
                 sourceStories
                     .map((item: any) => item?.story)
@@ -4076,17 +4116,30 @@ export const copyCommand = async (props: CLIOptions) => {
             const planGate = buildCopyPlanGateSummary({
                 sourceSpaceId: sourceSpace,
                 targetSpaceId: targetSpace,
-                plan: plan.map((item) => ({
-                    type: item.type,
-                    sourceId: sourceStoryByFullSlug.get(item.sourceFullSlug)
-                        ?.id,
-                    sourceFullSlug: item.sourceFullSlug,
-                    targetFullSlug: item.targetFullSlug,
-                })),
-                conflictTargetFullSlugs: conflicts.map(
-                    (conflict) => conflict.targetFullSlug,
-                ),
-                copyMaps,
+                plan: plan.map((item) => {
+                    const sourceId = sourceStoryByFullSlug.get(
+                        item.sourceFullSlug,
+                    )?.id;
+
+                    return {
+                        type: item.type,
+                        sourceFullSlug: item.sourceFullSlug,
+                        targetFullSlug: item.targetFullSlug,
+                        // A ledger mapping only survives the gate if the story
+                        // it points at is the one living at the planned target
+                        // path — the same rule `getValidMappedTargetStory`
+                        // applies per story once writing starts, answered here
+                        // from the target check the gate already ran.
+                        ledgerTargetStoryId:
+                            sourceId === undefined
+                                ? undefined
+                                : copyMaps.storyIds.get(Number(sourceId)),
+                        existingTargetStoryId:
+                            existingTargetStoryIdByFullSlug.get(
+                                item.targetFullSlug,
+                            ),
+                    };
+                }),
                 ledger,
                 graph: dryRunGraph,
                 withAssets,

--- a/src/cli/commands/copy.ts
+++ b/src/cli/commands/copy.ts
@@ -17,14 +17,18 @@ import path from "path";
 
 import {
     appendManifestEntry,
+    archiveCopyManifests,
     buildCopyAssetsGraph,
     buildCopyMaps,
+    buildCopyPlanGateSummary,
     buildCopyReferenceSelection,
     classifyStoryReferences,
     countStoryReferenceStatuses,
     createCopyGraph,
+    createEmptyCopyMaps,
     dedupeManifestFile,
     describeBrokenStoryReferenceTarget,
+    formatCopyPlanGate,
     getDefaultCopyManifestPaths,
     groupBrokenStoryReferences,
     loadManifest,
@@ -47,6 +51,7 @@ import { mapWithConcurrency } from "../../utils/async-utils.js";
 import Logger from "../../utils/logger.js";
 import { getFileName } from "../../utils/string-utils.js";
 import { apiConfig } from "../api-config.js";
+import { askYesNo } from "../helpers.js";
 
 const COPY_COMMANDS = {
     stories: "stories",
@@ -3812,6 +3817,34 @@ const logDryRunCopyAssetsPlan = async ({
     );
 };
 
+/**
+ * The single gate between planning and the first API write. `--yes` passes
+ * it (the plan still prints); without a terminal there is nobody to ask, so
+ * the run refuses rather than guessing.
+ */
+const confirmCopyPlan = async ({ yes }: { yes: boolean }): Promise<boolean> => {
+    if (yes) {
+        Logger.log("Continuing without confirmation (--yes).");
+        return true;
+    }
+
+    if (!process.stdin.isTTY) {
+        Logger.error(
+            "Refusing to write without confirmation: no interactive terminal. Re-run with --yes to continue, or --dry-run to only plan.",
+        );
+        process.exitCode = 1;
+        return false;
+    }
+
+    const confirmed = await askYesNo("Continue? [y/N]");
+
+    if (!confirmed) {
+        Logger.warning("Copy aborted before any write.");
+    }
+
+    return confirmed;
+};
+
 export const copyCommand = async (props: CLIOptions) => {
     const { input, flags } = props;
 
@@ -3836,6 +3869,8 @@ export const copyCommand = async (props: CLIOptions) => {
             const withAssets = Boolean(
                 flags["withAssets"] ?? flags["with-assets"],
             );
+            const yes = Boolean(flags["yes"]);
+            const fresh = Boolean(flags["fresh"]);
             const publication = await resolveCopyPublicationOptions({
                 flags,
                 targetSpace,
@@ -3879,13 +3914,32 @@ export const copyCommand = async (props: CLIOptions) => {
                 rootDir: manifestRoot,
             });
             const manifestEntries = await loadManifest(manifestPaths.combined);
-            const copyMaps = buildCopyMaps(manifestEntries);
+            const ledgerPath = path.resolve(manifestPaths.combined);
+            // --fresh: the ledger on disk is read only to be announced; the
+            // run plans and classifies against an empty one.
+            const copyMaps = fresh
+                ? createEmptyCopyMaps()
+                : buildCopyMaps(manifestEntries);
+            const ledger = {
+                path: ledgerPath,
+                entries: manifestEntries.length,
+                ignored: fresh,
+            };
+            Logger.warning(
+                fresh
+                    ? `Ledger: ${manifestEntries.length} entr${manifestEntries.length === 1 ? "y" : "ies"} at ${ledgerPath} IGNORED (--fresh).`
+                    : manifestEntries.length > 0
+                      ? `Ledger: ${manifestEntries.length} entr${manifestEntries.length === 1 ? "y" : "ies"} loaded from ${ledgerPath} (resuming; use --fresh to ignore).`
+                      : `Ledger: none at ${ledgerPath} (starting empty).`,
+            );
             let dryRunGraph: CopyGraph | undefined;
             let withAssetsGraph: CopyGraph | undefined;
             let sourceAssets: any[] = [];
             let sourceAssetFolders: any[] = [];
 
-            if (dryRun || withAssets) {
+            // The reference scan runs in apply mode too: the plan gate needs
+            // will-relink / will-break counts before the first write.
+            {
                 const schemasPromise =
                     buildComponentSchemaRegistry(sourceSpace);
 
@@ -3938,7 +3992,7 @@ export const copyCommand = async (props: CLIOptions) => {
                         `Reference planning complete. Found ${withAssetsGraph.assets.length} referenced asset(s), ${withAssetsGraph.assetFolders.length} asset folder(s), ${withAssetsGraph.assetReferences.length} asset reference occurrence(s), and ${withAssetsGraph.storyReferences.length} story reference occurrence(s).`,
                     );
                     dryRunGraph = withAssetsGraph;
-                } else if (dryRun) {
+                } else {
                     const schemas = await schemasPromise;
                     Logger.warning(
                         `Scanning ${countStoryItems(sourceStories)} stories for copy references.`,
@@ -4007,6 +4061,51 @@ export const copyCommand = async (props: CLIOptions) => {
                 }
 
                 break;
+            }
+
+            const conflicts = await findTargetConflicts(plan, targetSpace);
+            const sourceStoryByFullSlug = new Map(
+                sourceStories
+                    .map((item: any) => item?.story)
+                    .filter(Boolean)
+                    .map(
+                        (story: any) =>
+                            [String(story.full_slug ?? ""), story] as const,
+                    ),
+            );
+            const planGate = buildCopyPlanGateSummary({
+                sourceSpaceId: sourceSpace,
+                targetSpaceId: targetSpace,
+                plan: plan.map((item) => ({
+                    type: item.type,
+                    sourceId: sourceStoryByFullSlug.get(item.sourceFullSlug)
+                        ?.id,
+                    sourceFullSlug: item.sourceFullSlug,
+                    targetFullSlug: item.targetFullSlug,
+                })),
+                conflictTargetFullSlugs: conflicts.map(
+                    (conflict) => conflict.targetFullSlug,
+                ),
+                copyMaps,
+                ledger,
+                graph: dryRunGraph,
+                withAssets,
+            });
+
+            formatCopyPlanGate(planGate).forEach((line) => Logger.log(line));
+
+            if (!(await confirmCopyPlan({ yes }))) {
+                break;
+            }
+
+            if (fresh) {
+                const archived = await archiveCopyManifests(manifestPaths);
+
+                Logger.warning(
+                    archived.length > 0
+                        ? `--fresh: moved ${archived.length} ledger file(s) aside so this run starts empty: ${archived.join(", ")}`
+                        : "--fresh: no ledger files to move aside; starting empty.",
+                );
             }
 
             let assetCopyReport: CopyAssetsApplyReport | undefined;

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -47,3 +47,21 @@ export const askForConfirmation = async (
         rl.close();
     }
 };
+
+/**
+ * One yes/no question on the terminal. Resolves true only for an explicit
+ * `y`/`yes`; an empty answer or anything else is a no.
+ */
+export const askYesNo = async (message: string): Promise<boolean> => {
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+
+    try {
+        const answer = await rl.question(`${message} `);
+        return ["y", "yes"].includes(answer.trim().toLowerCase());
+    } finally {
+        rl.close();
+    }
+};


### PR DESCRIPTION
## Summary

`copy stories` (apply mode) now prints a PLAN block and asks `Continue? [y/N]` before its first write. Every piece of previously hidden state surfaces there: create / adopt-existing / resume-from-ledger counts, the ledger path and entry count, will-relink / will-break reference counts, and the asset count.

```
PLAN
  9 items (2 folders) -> space 222 (3 create, 1 adopt existing, 5 resume from ledger)
    1 existing target path will be adopted and UPDATED in place.
  ledger: 11 entries loaded from /abs/.sb-mig/copy/111/222/manifest.jsonl (resuming; use --fresh to ignore)
  references: 14 will relink, 4 leave your selection and WILL BREAK
  assets: 1 will copy, 0 already mapped
Continue? [y/N]
```

- `--yes` skips the question (CI); the plan still prints.
- No terminal and no `--yes`: the run refuses to write, prints why, exits non-zero.
- `--fresh`: the ledger on disk is announced but ignored for planning and classification; after the gate the existing manifest files are moved aside with a timestamp suffix (`manifest.jsonl.<ts>.bak`, never deleted) so the whole run, including the rewrite phase, really starts empty.
- The reference scan and the target-path check now run in apply mode too (previously dry-run only).
- The ledger is announced on every run, dry-run included: entry count, absolute path, resuming / empty / ignored.

Closes MAR-2669. Stacked on #396 (MAR-2670): the classifier this depends on. The diff includes #396's commits until it merges; review `0672ad3` alone for this phase.

## Design notes

- Plan composition is a pure module, `src/api/copy/plan-gate.ts`: `buildCopyPlanGateSummary` + `formatCopyPlanGate`, no I/O, own tests.
- Adoption is decided ledger-first, then target path: an item the ledger already maps counts as `resume`; otherwise an existing target path counts as `adopt` (`matched_by_target_key` at write time); otherwise `create`.
- `askYesNo` in `src/cli/helpers.ts` is a plain readline question; the existing `askForConfirmation` (3 s sleep, `process.exit`) was left untouched.
- Manifest JSONL format unchanged. Rewriter untouched. No new dependencies.

## Verification

- `npm run test:unit`: 58 files, **605/605** (11 new: 6 plan-gate unit tests, 5 CLI gate tests: non-TTY refusal, declined prompt, accepted prompt, pre-gate scan + target check, `--fresh` archive-and-start-empty). Existing apply-mode tests pass `yes: true`.
- `npm run lint`, `npm run typecheck`, `npm run build` clean.
- Built binary: `node dist/cli/index.js copy stories --from 1 --to 2 --source blog --destination imported --yes --fresh` routes and reaches the API (fails only on auth with dummy ids); `copy --help` lists both flags.
- Live probe not run: the probe credentials were cleaned from `/tmp` on Sep 1. The gate is exercised end to end in the CLI tests against the mocked management API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
