### PR TITLE
feat(copy): add copy relink, a standalone reference repair pass (MAR-2671)

### DIFF
--- a/__tests__/api/copy-manifest.test.ts
+++ b/__tests__/api/copy-manifest.test.ts
@@ -220,11 +220,11 @@ describe("copy graph model", () => {
             sourceStoryId: 100,
             referencedStoryId: 101,
             path: "content.related[0]",
-            status: "preserved_external",
+            status: "will_break",
         });
         graph.warnings.push({
-            code: "external_story_reference",
-            message: "External story reference preserved.",
+            code: "broken_story_reference",
+            message: "Story reference points outside this copy.",
         });
 
         expect(graph).toMatchObject({

--- a/__tests__/api/copy-plan-gate.test.ts
+++ b/__tests__/api/copy-plan-gate.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
     buildCopyPlanGateSummary,
     createCopyGraph,
-    createEmptyCopyMaps,
     formatCopyPlanGate,
 } from "../../src/api/copy/index.js";
 
@@ -16,19 +15,16 @@ const ledger = {
 const plan = [
     {
         type: "folder" as const,
-        sourceId: 1,
         sourceFullSlug: "blog",
         targetFullSlug: "imported/blog",
     },
     {
         type: "story" as const,
-        sourceId: 2,
         sourceFullSlug: "blog/post-1",
         targetFullSlug: "imported/blog/post-1",
     },
     {
         type: "story" as const,
-        sourceId: 3,
         sourceFullSlug: "blog/post-2",
         targetFullSlug: "imported/blog/post-2",
     },
@@ -52,6 +48,7 @@ const graphWithReferences = () => {
         {
             type: "story_reference",
             sourceStoryId: 2,
+            sourceStoryFullSlug: "blog/post-1",
             referencedStoryId: 3,
             path: "content.related[0]",
             status: "will_relink",
@@ -59,6 +56,7 @@ const graphWithReferences = () => {
         {
             type: "story_reference",
             sourceStoryId: 2,
+            sourceStoryFullSlug: "blog/post-1",
             referencedStoryUuid: "shared-header-uuid",
             path: "content.header",
             status: "will_break",
@@ -66,6 +64,7 @@ const graphWithReferences = () => {
         {
             type: "story_reference",
             sourceStoryId: 3,
+            sourceStoryFullSlug: "blog/post-2",
             referencedStoryUuid: "shared-footer-uuid",
             path: "content.footer",
             status: "external_kept",
@@ -91,20 +90,25 @@ const graphWithReferences = () => {
 
 describe("copy plan gate", () => {
     describe("buildCopyPlanGateSummary", () => {
-        it("splits the plan into create, adopt and resume by ledger first, then target path", () => {
-            const copyMaps = createEmptyCopyMaps();
-            copyMaps.storyIds.set(2, 9002);
-
+        it("splits the plan into create, adopt and resume", () => {
             const summary = buildCopyPlanGateSummary({
                 sourceSpaceId: "111",
                 targetSpaceId: "222",
-                plan,
-                // post-1 also exists at the target, but the ledger wins.
-                conflictTargetFullSlugs: [
-                    "imported/blog/post-1",
-                    "imported/blog/post-2",
+                plan: [
+                    plan[0],
+                    {
+                        // Mapped by the ledger to the story that really sits at
+                        // the target path: a resume.
+                        ...plan[1],
+                        ledgerTargetStoryId: 9002,
+                        existingTargetStoryId: 9002,
+                    },
+                    {
+                        // Unmapped, but the path is taken: adopted in place.
+                        ...plan[2],
+                        existingTargetStoryId: 9003,
+                    },
                 ],
-                copyMaps,
                 ledger: { ...ledger, entries: 1 },
                 withAssets: false,
             });
@@ -115,6 +119,7 @@ describe("copy plan gate", () => {
                 create: 1,
                 resume: 1,
                 adopt: 1,
+                staleLedger: 0,
             });
             expect(summary.references).toEqual({
                 scanned: false,
@@ -122,8 +127,42 @@ describe("copy plan gate", () => {
                 willRelink: 0,
                 willBreak: 0,
                 externalKept: 0,
+                breaking: [],
             });
             expect(summary.assets).toBeUndefined();
+        });
+
+        it("discards ledger mappings the target no longer backs", () => {
+            const summary = buildCopyPlanGateSummary({
+                sourceSpaceId: "111",
+                targetSpaceId: "222",
+                plan: [
+                    plan[0],
+                    {
+                        // Mapped, but the target story is gone: a create.
+                        ...plan[1],
+                        ledgerTargetStoryId: 5555,
+                    },
+                    {
+                        // Mapped, but a different story holds the path now:
+                        // the run adopts that one instead.
+                        ...plan[2],
+                        ledgerTargetStoryId: 5556,
+                        existingTargetStoryId: 9003,
+                    },
+                ],
+                ledger: { ...ledger, entries: 2 },
+                withAssets: false,
+            });
+
+            expect(summary.stories).toEqual({
+                total: 3,
+                folders: 1,
+                create: 2,
+                resume: 0,
+                adopt: 1,
+                staleLedger: 2,
+            });
         });
 
         it("counts classified references and planned assets from the graph", () => {
@@ -131,42 +170,27 @@ describe("copy plan gate", () => {
                 sourceSpaceId: "111",
                 targetSpaceId: "222",
                 plan,
-                conflictTargetFullSlugs: [],
-                copyMaps: createEmptyCopyMaps(),
                 ledger,
                 graph: graphWithReferences(),
                 withAssets: true,
             });
 
-            expect(summary.references).toEqual({
+            expect(summary.references).toMatchObject({
                 scanned: true,
                 total: 3,
                 willRelink: 1,
                 willBreak: 1,
                 externalKept: 1,
             });
+            expect(summary.references.breaking).toEqual([
+                {
+                    sourceStoryFullSlug: "blog/post-1",
+                    references: [
+                        expect.objectContaining({ path: "content.header" }),
+                    ],
+                },
+            ]);
             expect(summary.assets).toEqual({ toCopy: 1, mapped: 1 });
-        });
-
-        it("treats plan items without a resolved source id as creates", () => {
-            const copyMaps = createEmptyCopyMaps();
-            copyMaps.storyIds.set(2, 9002);
-
-            const summary = buildCopyPlanGateSummary({
-                sourceSpaceId: "111",
-                targetSpaceId: "222",
-                plan: plan.map(({ sourceId: _sourceId, ...item }) => item),
-                conflictTargetFullSlugs: [],
-                copyMaps,
-                ledger,
-                withAssets: false,
-            });
-
-            expect(summary.stories).toMatchObject({
-                create: 3,
-                resume: 0,
-                adopt: 0,
-            });
         });
     });
 
@@ -177,8 +201,6 @@ describe("copy plan gate", () => {
                     sourceSpaceId: "111",
                     targetSpaceId: "222",
                     plan,
-                    conflictTargetFullSlugs: [],
-                    copyMaps: createEmptyCopyMaps(),
                     ledger,
                     withAssets: false,
                 }),
@@ -194,16 +216,19 @@ describe("copy plan gate", () => {
         });
 
         it("names adoption, resumption, breaking references and assets", () => {
-            const copyMaps = createEmptyCopyMaps();
-            copyMaps.storyIds.set(3, 9003);
-
             const lines = formatCopyPlanGate(
                 buildCopyPlanGateSummary({
                     sourceSpaceId: "111",
                     targetSpaceId: "222",
-                    plan,
-                    conflictTargetFullSlugs: ["imported/blog/post-1"],
-                    copyMaps,
+                    plan: [
+                        plan[0],
+                        { ...plan[1], existingTargetStoryId: 9002 },
+                        {
+                            ...plan[2],
+                            ledgerTargetStoryId: 9003,
+                            existingTargetStoryId: 9003,
+                        },
+                    ],
                     ledger: { ...ledger, entries: 11 },
                     graph: graphWithReferences(),
                     withAssets: true,
@@ -216,8 +241,64 @@ describe("copy plan gate", () => {
                 "    1 existing target path will be adopted and UPDATED in place.",
                 "  ledger: 11 entries loaded from /repo/.sb-mig/copy/111/222/manifest.jsonl (resuming; use --fresh to ignore)",
                 "  references: 1 will relink, 1 leave your selection and WILL BREAK",
+                "    WILL BREAK, by story:",
+                "      blog/post-1",
+                "        content.header -> shared-header-uuid",
                 "  assets: 1 will copy, 1 already mapped",
             ]);
+        });
+
+        it("says how many ledger mappings went stale", () => {
+            const lines = formatCopyPlanGate(
+                buildCopyPlanGateSummary({
+                    sourceSpaceId: "111",
+                    targetSpaceId: "222",
+                    plan: [
+                        { ...plan[0], ledgerTargetStoryId: 5554 },
+                        { ...plan[1], ledgerTargetStoryId: 5555 },
+                        plan[2],
+                    ],
+                    ledger: { ...ledger, entries: 2 },
+                    withAssets: false,
+                }),
+            );
+
+            expect(lines[1]).toBe(
+                "  3 items (1 folder) -> space 222 (3 create, 0 adopt existing, 0 resume from ledger)",
+            );
+            expect(lines[2]).toBe(
+                "    2 ledger mappings no longer resolve in space 222 and will be discarded.",
+            );
+        });
+
+        it("caps the broken-reference listing and points at the dry run", () => {
+            const graph = graphWithReferences();
+
+            graph.storyReferences = Array.from({ length: 23 }, (_, index) => ({
+                type: "story_reference" as const,
+                sourceStoryId: 100 + index,
+                sourceStoryFullSlug: `blog/post-${index}`,
+                referencedStoryUuid: "shared-header-uuid",
+                path: "content.header",
+                status: "will_break" as const,
+            }));
+
+            const lines = formatCopyPlanGate(
+                buildCopyPlanGateSummary({
+                    sourceSpaceId: "111",
+                    targetSpaceId: "222",
+                    plan,
+                    ledger,
+                    graph,
+                    withAssets: false,
+                }),
+            );
+
+            expect(lines).toContain("      blog/post-19");
+            expect(lines).not.toContain("      blog/post-20");
+            expect(lines).toContain(
+                "      ...and 3 more stories with breaking references; run with --dryRun for the full list.",
+            );
         });
 
         it("marks an ignored ledger and shows kept references on a same-space copy", () => {
@@ -226,8 +307,6 @@ describe("copy plan gate", () => {
                     sourceSpaceId: "111",
                     targetSpaceId: "111",
                     plan,
-                    conflictTargetFullSlugs: [],
-                    copyMaps: createEmptyCopyMaps(),
                     ledger: { ...ledger, entries: 1, ignored: true },
                     graph: graphWithReferences(),
                     withAssets: false,

--- a/__tests__/api/copy-plan-gate.test.ts
+++ b/__tests__/api/copy-plan-gate.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    buildCopyPlanGateSummary,
+    createCopyGraph,
+    createEmptyCopyMaps,
+    formatCopyPlanGate,
+} from "../../src/api/copy/index.js";
+
+const ledger = {
+    path: "/repo/.sb-mig/copy/111/222/manifest.jsonl",
+    entries: 0,
+    ignored: false,
+};
+
+const plan = [
+    {
+        type: "folder" as const,
+        sourceId: 1,
+        sourceFullSlug: "blog",
+        targetFullSlug: "imported/blog",
+    },
+    {
+        type: "story" as const,
+        sourceId: 2,
+        sourceFullSlug: "blog/post-1",
+        targetFullSlug: "imported/blog/post-1",
+    },
+    {
+        type: "story" as const,
+        sourceId: 3,
+        sourceFullSlug: "blog/post-2",
+        targetFullSlug: "imported/blog/post-2",
+    },
+];
+
+const graphWithReferences = () => {
+    const graph = createCopyGraph({
+        sourceSpaceId: "111",
+        targetSpaceId: "222",
+        scope: {
+            command: "copy stories",
+            source: "blog",
+            destination: "imported",
+            mode: "subtree",
+            withAssets: true,
+            referencePolicy: "preserve",
+        },
+    });
+
+    graph.storyReferences.push(
+        {
+            type: "story_reference",
+            sourceStoryId: 2,
+            referencedStoryId: 3,
+            path: "content.related[0]",
+            status: "will_relink",
+        },
+        {
+            type: "story_reference",
+            sourceStoryId: 2,
+            referencedStoryUuid: "shared-header-uuid",
+            path: "content.header",
+            status: "will_break",
+        },
+        {
+            type: "story_reference",
+            sourceStoryId: 3,
+            referencedStoryUuid: "shared-footer-uuid",
+            path: "content.footer",
+            status: "external_kept",
+        },
+    );
+    graph.assets.push(
+        {
+            type: "asset",
+            sourceId: 300,
+            sourceFilename: "https://a.storyblok.com/f/111/a.jpg",
+            action: "create",
+        },
+        {
+            type: "asset",
+            sourceId: 301,
+            sourceFilename: "https://a.storyblok.com/f/111/b.jpg",
+            action: "match",
+        },
+    );
+
+    return graph;
+};
+
+describe("copy plan gate", () => {
+    describe("buildCopyPlanGateSummary", () => {
+        it("splits the plan into create, adopt and resume by ledger first, then target path", () => {
+            const copyMaps = createEmptyCopyMaps();
+            copyMaps.storyIds.set(2, 9002);
+
+            const summary = buildCopyPlanGateSummary({
+                sourceSpaceId: "111",
+                targetSpaceId: "222",
+                plan,
+                // post-1 also exists at the target, but the ledger wins.
+                conflictTargetFullSlugs: [
+                    "imported/blog/post-1",
+                    "imported/blog/post-2",
+                ],
+                copyMaps,
+                ledger: { ...ledger, entries: 1 },
+                withAssets: false,
+            });
+
+            expect(summary.stories).toEqual({
+                total: 3,
+                folders: 1,
+                create: 1,
+                resume: 1,
+                adopt: 1,
+            });
+            expect(summary.references).toEqual({
+                scanned: false,
+                total: 0,
+                willRelink: 0,
+                willBreak: 0,
+                externalKept: 0,
+            });
+            expect(summary.assets).toBeUndefined();
+        });
+
+        it("counts classified references and planned assets from the graph", () => {
+            const summary = buildCopyPlanGateSummary({
+                sourceSpaceId: "111",
+                targetSpaceId: "222",
+                plan,
+                conflictTargetFullSlugs: [],
+                copyMaps: createEmptyCopyMaps(),
+                ledger,
+                graph: graphWithReferences(),
+                withAssets: true,
+            });
+
+            expect(summary.references).toEqual({
+                scanned: true,
+                total: 3,
+                willRelink: 1,
+                willBreak: 1,
+                externalKept: 1,
+            });
+            expect(summary.assets).toEqual({ toCopy: 1, mapped: 1 });
+        });
+
+        it("treats plan items without a resolved source id as creates", () => {
+            const copyMaps = createEmptyCopyMaps();
+            copyMaps.storyIds.set(2, 9002);
+
+            const summary = buildCopyPlanGateSummary({
+                sourceSpaceId: "111",
+                targetSpaceId: "222",
+                plan: plan.map(({ sourceId: _sourceId, ...item }) => item),
+                conflictTargetFullSlugs: [],
+                copyMaps,
+                ledger,
+                withAssets: false,
+            });
+
+            expect(summary.stories).toMatchObject({
+                create: 3,
+                resume: 0,
+                adopt: 0,
+            });
+        });
+    });
+
+    describe("formatCopyPlanGate", () => {
+        it("prints an empty ledger, unscanned references and no assets honestly", () => {
+            const lines = formatCopyPlanGate(
+                buildCopyPlanGateSummary({
+                    sourceSpaceId: "111",
+                    targetSpaceId: "222",
+                    plan,
+                    conflictTargetFullSlugs: [],
+                    copyMaps: createEmptyCopyMaps(),
+                    ledger,
+                    withAssets: false,
+                }),
+            );
+
+            expect(lines).toEqual([
+                "PLAN",
+                "  3 items (1 folder) -> space 222 (3 create, 0 adopt existing, 0 resume from ledger)",
+                "  ledger: none at /repo/.sb-mig/copy/111/222/manifest.jsonl (starting empty)",
+                "  references: not scanned",
+                "  assets: not copied (pass --with-assets)",
+            ]);
+        });
+
+        it("names adoption, resumption, breaking references and assets", () => {
+            const copyMaps = createEmptyCopyMaps();
+            copyMaps.storyIds.set(3, 9003);
+
+            const lines = formatCopyPlanGate(
+                buildCopyPlanGateSummary({
+                    sourceSpaceId: "111",
+                    targetSpaceId: "222",
+                    plan,
+                    conflictTargetFullSlugs: ["imported/blog/post-1"],
+                    copyMaps,
+                    ledger: { ...ledger, entries: 11 },
+                    graph: graphWithReferences(),
+                    withAssets: true,
+                }),
+            );
+
+            expect(lines).toEqual([
+                "PLAN",
+                "  3 items (1 folder) -> space 222 (1 create, 1 adopt existing, 1 resume from ledger)",
+                "    1 existing target path will be adopted and UPDATED in place.",
+                "  ledger: 11 entries loaded from /repo/.sb-mig/copy/111/222/manifest.jsonl (resuming; use --fresh to ignore)",
+                "  references: 1 will relink, 1 leave your selection and WILL BREAK",
+                "  assets: 1 will copy, 1 already mapped",
+            ]);
+        });
+
+        it("marks an ignored ledger and shows kept references on a same-space copy", () => {
+            const lines = formatCopyPlanGate(
+                buildCopyPlanGateSummary({
+                    sourceSpaceId: "111",
+                    targetSpaceId: "111",
+                    plan,
+                    conflictTargetFullSlugs: [],
+                    copyMaps: createEmptyCopyMaps(),
+                    ledger: { ...ledger, entries: 1, ignored: true },
+                    graph: graphWithReferences(),
+                    withAssets: false,
+                }),
+            );
+
+            expect(lines[2]).toBe(
+                "  ledger: 1 entry at /repo/.sb-mig/copy/111/222/manifest.jsonl IGNORED (--fresh; starting empty)",
+            );
+            expect(lines[3]).toBe(
+                "  references: 1 will relink, 1 outside the selection kept (same space), 1 leave your selection and WILL BREAK",
+            );
+        });
+    });
+});

--- a/__tests__/api/copy-reference-classifier.test.ts
+++ b/__tests__/api/copy-reference-classifier.test.ts
@@ -195,17 +195,6 @@ describe("copy reference classifier", () => {
             expect(classified.status).toBe("will_relink");
         });
 
-        it("does classify alternates as ordinary content references", () => {
-            const [classified] = classify([
-                reference({
-                    path: "alternates[0].parent_id",
-                    referencedStoryId: 999,
-                }),
-            ]);
-
-            expect(classified.status).toBe("will_break");
-        });
-
         it("leaves scanner-decided statuses untouched", () => {
             const classified = classify([
                 reference({

--- a/__tests__/api/copy-reference-classifier.test.ts
+++ b/__tests__/api/copy-reference-classifier.test.ts
@@ -1,0 +1,330 @@
+import type {
+    CopyGraphStoryNode,
+    CopyGraphStoryReference,
+    CopyMaps,
+} from "../../src/api/copy/types.js";
+
+import { describe, expect, it } from "vitest";
+
+import {
+    buildCopyReferenceSelection,
+    classifyStoryReferences,
+    countStoryReferenceStatuses,
+    createEmptyCopyMaps,
+    createEmptyCopyReferenceSelection,
+    describeBrokenStoryReferenceTarget,
+    groupBrokenStoryReferences,
+} from "../../src/api/copy/index.js";
+
+const storyNode = (
+    sourceId: number,
+    sourceUuid: string,
+    sourceFullSlug: string,
+): CopyGraphStoryNode => ({
+    type: "story",
+    sourceId,
+    sourceUuid,
+    sourceFullSlug,
+    action: "create",
+});
+
+const reference = (
+    overrides: Partial<CopyGraphStoryReference>,
+): CopyGraphStoryReference => ({
+    type: "story_reference",
+    sourceStoryId: 10,
+    sourceStoryUuid: "page-one-uuid",
+    sourceStoryFullSlug: "probe/pages/page-one",
+    path: "content.ref_link.id",
+    status: "unclassified",
+    ...overrides,
+});
+
+const ledgerWith = ({
+    storyIds = [] as Array<[number, number]>,
+    storyUuids = [] as Array<[string, string]>,
+}): CopyMaps => {
+    const maps = createEmptyCopyMaps();
+
+    for (const [source, target] of storyIds) {
+        maps.storyIds.set(source, target);
+    }
+
+    for (const [source, target] of storyUuids) {
+        maps.storyUuids.set(source, target);
+    }
+
+    return maps;
+};
+
+const classify = (
+    references: CopyGraphStoryReference[],
+    {
+        stories = [] as CopyGraphStoryNode[],
+        copyMaps = createEmptyCopyMaps(),
+        sameSpace = false,
+    } = {},
+) =>
+    classifyStoryReferences({
+        storyReferences: references,
+        selection: buildCopyReferenceSelection(stories),
+        copyMaps,
+        sameSpace,
+    });
+
+describe("copy reference classifier", () => {
+    describe("buildCopyReferenceSelection", () => {
+        it("collects plan story ids and uuids", () => {
+            const selection = buildCopyReferenceSelection([
+                storyNode(10, "page-one-uuid", "probe/pages/page-one"),
+                storyNode(11, "page-two-uuid", "probe/pages/page-two"),
+            ]);
+
+            expect(Array.from(selection.storyIds)).toEqual([10, 11]);
+            expect(Array.from(selection.storyUuids)).toEqual([
+                "page-one-uuid",
+                "page-two-uuid",
+            ]);
+        });
+
+        it("ignores unresolved plan items carrying sourceId 0", () => {
+            const selection = buildCopyReferenceSelection([
+                { ...storyNode(0, "", "probe/pages"), sourceUuid: undefined },
+            ]);
+
+            expect(selection.storyIds.size).toBe(0);
+            expect(selection.storyUuids.size).toBe(0);
+        });
+
+        it("creates an empty selection", () => {
+            const selection = createEmptyCopyReferenceSelection();
+
+            expect(selection.storyIds.size).toBe(0);
+            expect(selection.storyUuids.size).toBe(0);
+        });
+    });
+
+    describe("classifyStoryReferences", () => {
+        it("marks a reference into the selection will_relink by uuid", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryUuid: "shared-header-uuid" })],
+                {
+                    stories: [
+                        storyNode(
+                            20,
+                            "shared-header-uuid",
+                            "probe/shared/shared-header",
+                        ),
+                    ],
+                },
+            );
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("marks a reference into the selection will_relink by id", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryId: 20 })],
+                {
+                    stories: [
+                        storyNode(
+                            20,
+                            "shared-header-uuid",
+                            "probe/shared/shared-header",
+                        ),
+                    ],
+                },
+            );
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("marks a reference already in the ledger will_relink", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryUuid: "earlier-copy-uuid" })],
+                {
+                    copyMaps: ledgerWith({
+                        storyUuids: [["earlier-copy-uuid", "target-uuid"]],
+                    }),
+                },
+            );
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("marks an out-of-scope reference will_break in a cross-space copy", () => {
+            const [classified] = classify([
+                reference({ referencedStoryUuid: "playground-page-uuid" }),
+            ]);
+
+            expect(classified.status).toBe("will_break");
+        });
+
+        it("marks an out-of-scope reference external_kept in a same-space copy", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryUuid: "playground-page-uuid" })],
+                { sameSpace: true },
+            );
+
+            expect(classified.status).toBe("external_kept");
+        });
+
+        it("still relinks in-scope references in a same-space copy", () => {
+            const [classified] = classify(
+                [reference({ referencedStoryUuid: "shared-header-uuid" })],
+                {
+                    sameSpace: true,
+                    stories: [
+                        storyNode(
+                            20,
+                            "shared-header-uuid",
+                            "probe/shared/shared-header",
+                        ),
+                    ],
+                },
+            );
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("never breaks parent_id, which the copy plan resolves structurally", () => {
+            const [classified] = classify([
+                reference({ path: "parent_id", referencedStoryId: 999 }),
+            ]);
+
+            expect(classified.status).toBe("will_relink");
+        });
+
+        it("does classify alternates as ordinary content references", () => {
+            const [classified] = classify([
+                reference({
+                    path: "alternates[0].parent_id",
+                    referencedStoryId: 999,
+                }),
+            ]);
+
+            expect(classified.status).toBe("will_break");
+        });
+
+        it("leaves scanner-decided statuses untouched", () => {
+            const classified = classify([
+                reference({
+                    referencedStoryUuid: "playground-page-uuid",
+                    status: "unresolved",
+                }),
+                reference({
+                    referencedStoryUuid: "playground-page-uuid",
+                    status: "unsupported",
+                }),
+            ]);
+
+            expect(classified.map((item) => item.status)).toEqual([
+                "unresolved",
+                "unsupported",
+            ]);
+        });
+
+        it("does not mutate the references it is given", () => {
+            const original = reference({
+                referencedStoryUuid: "playground-page-uuid",
+            });
+
+            classify([original]);
+
+            expect(original.status).toBe("unclassified");
+        });
+    });
+
+    describe("countStoryReferenceStatuses", () => {
+        it("counts every status bucket", () => {
+            const counts = countStoryReferenceStatuses([
+                reference({ status: "will_relink" }),
+                reference({ status: "will_relink" }),
+                reference({ status: "will_break" }),
+                reference({ status: "external_kept" }),
+                reference({ status: "unresolved" }),
+                reference({ status: "unsupported" }),
+                reference({ status: "unclassified" }),
+            ]);
+
+            expect(counts).toEqual({
+                willRelink: 2,
+                willBreak: 1,
+                externalKept: 1,
+                unresolved: 1,
+                unsupported: 1,
+                unclassified: 1,
+            });
+        });
+    });
+
+    describe("groupBrokenStoryReferences", () => {
+        it("groups breaks by the story that holds them", () => {
+            const groups = groupBrokenStoryReferences([
+                reference({
+                    status: "will_break",
+                    path: "content.ref_link.id",
+                    referencedStoryUuid: "outside-uuid",
+                }),
+                reference({
+                    status: "will_break",
+                    path: "content.body[0].reference",
+                    referencedStoryUuid: "outside-uuid",
+                }),
+                reference({
+                    status: "will_relink",
+                    path: "content.related",
+                }),
+                reference({
+                    status: "will_break",
+                    sourceStoryFullSlug: "probe/pages/page-four",
+                    path: "content.ref_link.id",
+                    referencedStoryId: 777,
+                }),
+            ]);
+
+            expect(
+                groups.map((group) => [
+                    group.sourceStoryFullSlug,
+                    group.references.map((item) => item.path),
+                ]),
+            ).toEqual([
+                [
+                    "probe/pages/page-one",
+                    ["content.ref_link.id", "content.body[0].reference"],
+                ],
+                ["probe/pages/page-four", ["content.ref_link.id"]],
+            ]);
+        });
+
+        it("falls back to the source story id when the slug is missing", () => {
+            const [group] = groupBrokenStoryReferences([
+                reference({
+                    status: "will_break",
+                    sourceStoryFullSlug: undefined,
+                    sourceStoryId: 42,
+                }),
+            ]);
+
+            expect(group.sourceStoryFullSlug).toBe("#42");
+        });
+    });
+
+    describe("describeBrokenStoryReferenceTarget", () => {
+        it("prefers the uuid, then the id", () => {
+            expect(
+                describeBrokenStoryReferenceTarget(
+                    reference({ referencedStoryUuid: "outside-uuid" }),
+                ),
+            ).toBe("outside-uuid");
+            expect(
+                describeBrokenStoryReferenceTarget(
+                    reference({ referencedStoryId: 777 }),
+                ),
+            ).toBe("#777");
+            expect(describeBrokenStoryReferenceTarget(reference({}))).toBe(
+                "<unknown target>",
+            );
+        });
+    });
+});

--- a/__tests__/api/copy-reference-scanner.test.ts
+++ b/__tests__/api/copy-reference-scanner.test.ts
@@ -31,6 +31,7 @@ const story = {
     uuid: "story-uuid-100",
     full_slug: "blog/post",
     parent_id: 90,
+    // Read-only API metadata: stripped before write, so never scanned.
     alternates: [{ id: 101, parent_id: 91 }],
     content: {
         component: "page",
@@ -205,16 +206,6 @@ describe("copy reference scanner", () => {
             expect.objectContaining({
                 referencedStoryId: 90,
                 path: "parent_id",
-                status: "unclassified",
-            }),
-            expect.objectContaining({
-                referencedStoryId: 101,
-                path: "alternates[0].id",
-                status: "unclassified",
-            }),
-            expect.objectContaining({
-                referencedStoryId: 91,
-                path: "alternates[0].parent_id",
                 status: "unclassified",
             }),
             expect.objectContaining({

--- a/__tests__/api/copy-reference-scanner.test.ts
+++ b/__tests__/api/copy-reference-scanner.test.ts
@@ -205,42 +205,42 @@ describe("copy reference scanner", () => {
             expect.objectContaining({
                 referencedStoryId: 90,
                 path: "parent_id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 101,
                 path: "alternates[0].id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 91,
                 path: "alternates[0].parent_id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 102,
                 path: "content.hero[0].cta.id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryUuid: "story-uuid-103",
                 path: "content.hero[0].body.content[0].content[0].attrs.uuid",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 104,
                 path: "content.hero[0].body.content[1].attrs.body[0].link.id",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 105,
                 path: "content.related[0]",
-                status: "preserved_external",
+                status: "unclassified",
             }),
             expect.objectContaining({
                 referencedStoryId: 106,
                 path: "content.related[1]",
-                status: "preserved_external",
+                status: "unclassified",
             }),
         ]);
 

--- a/__tests__/api/copy-relink.test.ts
+++ b/__tests__/api/copy-relink.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    buildCopyRelinkPlanSummary,
+    createEmptyCopyMaps,
+    formatCopyRelinkPlan,
+    planCopyRelinkStoryRewrite,
+    type CopyRelinkPlanItem,
+} from "../../src/api/copy/index.js";
+
+const ledger = {
+    path: "/repo/.sb-mig/copy/111/222/manifest.jsonl",
+    entries: 0,
+    ignored: false,
+};
+
+const references = {
+    scanned: true,
+    total: 3,
+    willRelink: 2,
+    willBreak: 1,
+    externalKept: 0,
+    breaking: [
+        {
+            sourceStoryFullSlug: "blog/post-2",
+            references: [
+                {
+                    type: "story_reference" as const,
+                    sourceStoryId: 3,
+                    referencedStoryUuid: "shared-header-uuid",
+                    path: "content.header",
+                    status: "will_break" as const,
+                },
+            ],
+        },
+    ],
+};
+
+const plan: CopyRelinkPlanItem[] = [
+    {
+        type: "folder",
+        sourceFullSlug: "blog",
+        targetFullSlug: "imported/blog",
+        match: "adopted",
+        rewrittenReferences: 0,
+        changed: false,
+    },
+    {
+        type: "story",
+        sourceFullSlug: "blog/post-1",
+        targetFullSlug: "imported/blog/post-1",
+        match: "ledger",
+        rewrittenReferences: 4,
+        changed: true,
+    },
+    {
+        type: "story",
+        sourceFullSlug: "blog/post-2",
+        targetFullSlug: "imported/blog/post-2",
+        match: "adopted",
+        rewrittenReferences: 0,
+        changed: false,
+    },
+    {
+        type: "story",
+        sourceFullSlug: "blog/post-3",
+        targetFullSlug: "imported/blog/post-3",
+        match: "missing",
+        rewrittenReferences: 0,
+        changed: false,
+    },
+];
+
+describe("copy relink", () => {
+    describe("buildCopyRelinkPlanSummary", () => {
+        it("counts how each planned story was matched and what will change", () => {
+            const summary = buildCopyRelinkPlanSummary({
+                sourceSpaceId: "111",
+                targetSpaceId: "222",
+                plan,
+                ledger,
+                references,
+            });
+
+            expect(summary.stories).toEqual({
+                total: 4,
+                folders: 1,
+                fromLedger: 1,
+                adopted: 2,
+                missing: 1,
+                toUpdate: 1,
+                // The folder is neither updated nor "already correct".
+                unchanged: 1,
+            });
+            expect(summary.rewrittenReferences).toBe(4);
+            expect(summary.sameSpace).toBe(false);
+        });
+
+        it("never counts references of a story it will not write", () => {
+            const summary = buildCopyRelinkPlanSummary({
+                sourceSpaceId: "111",
+                targetSpaceId: "222",
+                plan: [
+                    {
+                        ...plan[1],
+                        // A rewrite that maps every value to itself.
+                        rewrittenReferences: 7,
+                        changed: false,
+                    },
+                ],
+                ledger,
+                references,
+            });
+
+            expect(summary.rewrittenReferences).toBe(0);
+            expect(summary.stories.toUpdate).toBe(0);
+        });
+    });
+
+    describe("formatCopyRelinkPlan", () => {
+        it("states the matches, the exact rewrite and what it will not do", () => {
+            const lines = formatCopyRelinkPlan(
+                buildCopyRelinkPlanSummary({
+                    sourceSpaceId: "111",
+                    targetSpaceId: "222",
+                    plan,
+                    ledger: { ...ledger, entries: 9 },
+                    references,
+                }),
+            );
+
+            expect(lines).toEqual([
+                "PLAN",
+                "  4 planned items (1 folder) in space 222 (1 mapped by ledger, 2 adopted by target path, 1 missing from target)",
+                "    2 target stories will be added to the ledger as matched_by_target_key.",
+                "    1 planned story is not in the target and cannot be relinked; copy it first.",
+                "  ledger: 9 entries loaded from /repo/.sb-mig/copy/111/222/manifest.jsonl (resuming; use --fresh to ignore)",
+                "  references: 2 will relink, 1 leave your selection and WILL BREAK",
+                "    WILL BREAK, by story:",
+                "      blog/post-2",
+                "        content.header -> shared-header-uuid",
+                "  rewrite: 4 references in 1 story; 1 already correct and left untouched",
+                "  content: only reference values change; nothing is copied from the source",
+            ]);
+        });
+
+        it("says plainly when there is nothing to repair", () => {
+            const lines = formatCopyRelinkPlan(
+                buildCopyRelinkPlanSummary({
+                    sourceSpaceId: "111",
+                    targetSpaceId: "222",
+                    plan: [plan[2]],
+                    ledger,
+                    references: { ...references, willBreak: 0, breaking: [] },
+                }),
+            );
+
+            expect(lines).toContain(
+                "  rewrite: 0 references in 0 stories; 1 already correct and left untouched",
+            );
+            expect(lines).not.toContain(
+                "    1 planned story is not in the target and cannot be relinked; copy it first.",
+            );
+        });
+    });
+
+    describe("planCopyRelinkStoryRewrite", () => {
+        const brokenContent = () => ({
+            component: "page",
+            cta: {
+                linktype: "story",
+                id: 1,
+                uuid: "source-blog-uuid",
+            },
+        });
+
+        it("remaps the target story's own references", () => {
+            const maps = createEmptyCopyMaps();
+
+            maps.storyIds.set(1, 1001);
+            maps.storyUuids.set("source-blog-uuid", "target-blog-uuid");
+
+            const rewrite = planCopyRelinkStoryRewrite({
+                content: brokenContent(),
+                maps,
+            });
+
+            expect(rewrite.changed).toBe(true);
+            expect(rewrite.content).toEqual({
+                component: "page",
+                cta: {
+                    linktype: "story",
+                    id: 1001,
+                    uuid: "target-blog-uuid",
+                },
+            });
+        });
+
+        it("reports no change when nothing in the mapping applies", () => {
+            const maps = createEmptyCopyMaps();
+
+            maps.storyUuids.set("some-other-uuid", "target-other-uuid");
+
+            const rewrite = planCopyRelinkStoryRewrite({
+                content: brokenContent(),
+                maps,
+            });
+
+            expect(rewrite.changed).toBe(false);
+            expect(rewrite.rewrittenReferences).toBe(0);
+            expect(rewrite.content).toEqual(brokenContent());
+        });
+
+        it("reports no change when every mapped value maps to itself", () => {
+            const maps = createEmptyCopyMaps();
+
+            maps.storyIds.set(1, 1);
+            maps.storyUuids.set("source-blog-uuid", "source-blog-uuid");
+
+            const rewrite = planCopyRelinkStoryRewrite({
+                content: brokenContent(),
+                maps,
+            });
+
+            // Whatever the rewriter records, the stored content is identical,
+            // so the story must not be written.
+            expect(rewrite.changed).toBe(false);
+            expect(rewrite.content).toEqual(brokenContent());
+        });
+    });
+});

--- a/__tests__/api/copy-relink.test.ts
+++ b/__tests__/api/copy-relink.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 
 import {
+    buildCopyMaps,
+    buildCopyRelinkClassificationMaps,
+    buildCopyRelinkMaps,
     buildCopyRelinkPlanSummary,
     createEmptyCopyMaps,
     formatCopyRelinkPlan,
     planCopyRelinkStoryRewrite,
+    selectRelinkLedgerStoryMappings,
+    type CopyManifestEntry,
     type CopyRelinkPlanItem,
 } from "../../src/api/copy/index.js";
 
@@ -134,11 +139,18 @@ describe("copy relink", () => {
                 "  4 planned items (1 folder) in space 222 (1 mapped by ledger, 2 adopted by target path, 1 missing from target)",
                 "    2 target stories will be added to the ledger as matched_by_target_key.",
                 "    1 planned story is not in the target and cannot be relinked; copy it first.",
-                "  ledger: 9 entries loaded from /repo/.sb-mig/copy/111/222/manifest.jsonl (resuming; use --fresh to ignore)",
-                "  references: 2 will relink, 1 leave your selection and WILL BREAK",
+                // relink has no --fresh, so the shared ledger line must not
+                // advertise it.
+                "  ledger: 9 entries loaded from /repo/.sb-mig/copy/111/222/manifest.jsonl (completing the mapping from the target space)",
+                // The counts come from the source scan; the rewrite line below
+                // is the target. The label says so instead of implying one is
+                // the other.
+                "  source references: 2 will relink, 1 leave your selection and WILL BREAK",
+                "    Counted in the source content this selection covers, against the mapping above; the rewrite line below is what changes in the target.",
                 "    WILL BREAK, by story:",
                 "      blog/post-2",
                 "        content.header -> shared-header-uuid",
+                "    References into the story missing from the target cannot be repaired here; copy it first, then relink again.",
                 "  rewrite: 4 references in 1 story; 1 already correct and left untouched",
                 "  content: only reference values change; nothing is copied from the source",
             ]);
@@ -226,6 +238,192 @@ describe("copy relink", () => {
             // so the story must not be written.
             expect(rewrite.changed).toBe(false);
             expect(rewrite.content).toEqual(brokenContent());
+        });
+    });
+
+    describe("buildCopyRelinkMaps", () => {
+        const ledgerEntry = (
+            overrides: Partial<CopyManifestEntry> = {},
+        ): CopyManifestEntry =>
+            ({
+                type: "story",
+                source_space_id: "111",
+                target_space_id: "222",
+                source_id: 1,
+                target_id: 1001,
+                source_uuid: "source-blog-uuid",
+                target_uuid: "target-blog-uuid",
+                source_full_slug: "blog",
+                target_full_slug: "imported/blog",
+                action: "created",
+                created_at: "2026-09-03T00:00:00.000Z",
+                ...overrides,
+            }) as CopyManifestEntry;
+
+        it("carries only validated story mappings, never the ledger's own", () => {
+            const ledgerMaps = buildCopyMaps([
+                ledgerEntry(),
+                ledgerEntry({
+                    source_id: 3,
+                    source_uuid: "source-gone-uuid",
+                    target_id: 3003,
+                    target_uuid: "deleted-target-uuid",
+                }),
+                {
+                    type: "asset",
+                    source_space_id: "111",
+                    target_space_id: "222",
+                    source_id: 7,
+                    target_id: 7007,
+                    source_filename: "a.png",
+                    target_filename: "b.png",
+                    action: "created",
+                    created_at: "2026-09-03T00:00:00.000Z",
+                } as CopyManifestEntry,
+            ]);
+
+            const maps = buildCopyRelinkMaps({
+                ledgerMaps,
+                storyMappings: [
+                    {
+                        sourceId: 1,
+                        sourceUuid: "source-blog-uuid",
+                        targetId: 1001,
+                        targetUuid: "target-blog-uuid",
+                        sourceFullSlug: "blog",
+                        targetFullSlug: "imported/blog",
+                    },
+                ],
+            });
+
+            // The mapping whose target is gone must not survive into a map the
+            // rewriter writes through.
+            expect(maps.storyIds.get(1)).toBe(1001);
+            expect(maps.storyIds.has(3)).toBe(false);
+            expect(maps.storyUuids.has("source-gone-uuid")).toBe(false);
+            // Asset mappings are untouched by a story match.
+            expect(maps.assetIds.get(7)).toEqual({
+                id: 7007,
+                filename: "b.png",
+            });
+        });
+    });
+
+    describe("buildCopyRelinkClassificationMaps", () => {
+        it("keeps what the ledger covers and drops only what was proven stale", () => {
+            const ledgerMaps = createEmptyCopyMaps();
+
+            ledgerMaps.storyIds.set(5, 5005);
+            ledgerMaps.storyUuids.set(
+                "shared-header-uuid",
+                "target-header-uuid",
+            );
+            ledgerMaps.storyIds.set(3, 3003);
+            ledgerMaps.storyUuids.set(
+                "source-gone-uuid",
+                "deleted-target-uuid",
+            );
+
+            const maps = buildCopyRelinkClassificationMaps({
+                ledgerMaps,
+                storyMappings: [
+                    {
+                        sourceId: 1,
+                        sourceUuid: "source-blog-uuid",
+                        targetId: 1001,
+                        targetUuid: "target-blog-uuid",
+                        sourceFullSlug: "blog",
+                        targetFullSlug: "imported/blog",
+                    },
+                ],
+                staleStoryKeys: [
+                    { sourceId: 3, sourceUuid: "source-gone-uuid" },
+                ],
+            });
+
+            // A reference the ledger covers is not a break just because this
+            // run never had to touch it...
+            expect(maps.storyUuids.get("shared-header-uuid")).toBe(
+                "target-header-uuid",
+            );
+            expect(maps.storyUuids.get("source-blog-uuid")).toBe(
+                "target-blog-uuid",
+            );
+            // ...but a mapping this run proved stale cannot be counted as one.
+            expect(maps.storyIds.has(3)).toBe(false);
+            expect(maps.storyUuids.has("source-gone-uuid")).toBe(false);
+            // The ledger's own maps are not mutated.
+            expect(ledgerMaps.storyIds.has(3)).toBe(true);
+        });
+    });
+
+    describe("selectRelinkLedgerStoryMappings", () => {
+        const entries: CopyManifestEntry[] = [
+            {
+                type: "story",
+                source_space_id: "111",
+                target_space_id: "222",
+                source_id: 5,
+                target_id: 5005,
+                source_uuid: "shared-header-uuid",
+                target_uuid: "target-header-uuid",
+                source_full_slug: "shared/header",
+                target_full_slug: "imported/shared/header",
+                action: "created",
+                created_at: "2026-09-03T00:00:00.000Z",
+            },
+            {
+                type: "story",
+                source_space_id: "111",
+                target_space_id: "222",
+                source_id: 6,
+                target_id: 6006,
+                source_uuid: "unreferenced-uuid",
+                target_uuid: "target-unreferenced-uuid",
+                source_full_slug: "shared/footer",
+                target_full_slug: "imported/shared/footer",
+                action: "created",
+                created_at: "2026-09-03T00:00:00.000Z",
+            },
+        ];
+
+        it("picks the out-of-selection mappings the target content mentions", () => {
+            const mappings = selectRelinkLedgerStoryMappings({
+                entries,
+                plannedSourceIds: new Set([1, 2]),
+                targetContents: [
+                    {
+                        component: "page",
+                        header: { uuid: "shared-header-uuid" },
+                    },
+                ],
+            });
+
+            expect(mappings).toEqual([
+                {
+                    sourceId: 5,
+                    sourceUuid: "shared-header-uuid",
+                    targetId: 5005,
+                    targetUuid: "target-header-uuid",
+                    sourceFullSlug: "shared/header",
+                    targetFullSlug: "imported/shared/header",
+                },
+            ]);
+        });
+
+        it("leaves planned stories to the run's own target matching", () => {
+            expect(
+                selectRelinkLedgerStoryMappings({
+                    entries,
+                    plannedSourceIds: new Set([5, 6]),
+                    targetContents: [
+                        {
+                            component: "page",
+                            header: { uuid: "shared-header-uuid" },
+                        },
+                    ],
+                }),
+            ).toEqual([]);
         });
     });
 });

--- a/__tests__/cli/copy-assets-dry-run.test.ts
+++ b/__tests__/cli/copy-assets-dry-run.test.ts
@@ -453,6 +453,18 @@ describe("copy assets dry-run", () => {
                 status: "planned",
             },
         ]);
+        // An asset-only run never rewrites stories, so story references keep
+        // the scanner's neutral status and raise no break warnings.
+        expect(
+            report.graph.storyReferences.every(
+                (reference: any) => reference.status === "unclassified",
+            ),
+        ).toBe(true);
+        expect(
+            report.graph.warnings.filter(
+                (warning: any) => warning.code === "broken_story_reference",
+            ),
+        ).toEqual([]);
         expect(report.commands.apply).toBe(
             "sb-mig copy assets --from source-space --to target-space --referenced-by-stories --source blog/post --mode subtree",
         );

--- a/__tests__/cli/copy-dry-run.test.ts
+++ b/__tests__/cli/copy-dry-run.test.ts
@@ -552,7 +552,13 @@ describe("copy stories dry-run", () => {
                 assetFolders: 2,
                 assets: 1,
                 assetReferences: 1,
-                storyReferences: 4,
+                // parent_id 0 (the space root) is not a story reference: blog
+                // -> post-1, post-1 -> blog, and post-1's parent_id.
+                storyReferences: 3,
+                storyReferencesWillRelink: 3,
+                storyReferencesWillBreak: 0,
+                storyReferencesExternalKept: 0,
+                storyReferencesUnresolved: 0,
                 errors: 0,
             },
             graph: {
@@ -1531,19 +1537,21 @@ describe("copy stories dry-run", () => {
             },
         });
         const getStoryBySlug = mocks.getStoryBySlug.getMockImplementation();
-        mocks.getStoryBySlug.mockImplementation((slug: string, options: any) => {
-            if (slug === "imported/blog") {
-                return Promise.resolve({
-                    story: {
-                        id: 9999,
-                        uuid: "stale-target-blog-uuid",
-                        full_slug: "imported/blog",
-                    },
-                });
-            }
+        mocks.getStoryBySlug.mockImplementation(
+            (slug: string, options: any) => {
+                if (slug === "imported/blog") {
+                    return Promise.resolve({
+                        story: {
+                            id: 9999,
+                            uuid: "stale-target-blog-uuid",
+                            full_slug: "imported/blog",
+                        },
+                    });
+                }
 
-            return getStoryBySlug?.(slug, options);
-        });
+                return getStoryBySlug?.(slug, options);
+            },
+        );
         mocks.updateStory
             .mockResolvedValueOnce({
                 ok: false,

--- a/__tests__/cli/copy-dry-run.test.ts
+++ b/__tests__/cli/copy-dry-run.test.ts
@@ -78,6 +78,13 @@ vi.mock("../../src/utils/logger.js", () => ({
 }));
 
 import { copyCommand } from "../../src/cli/commands/copy.js";
+import Logger from "../../src/utils/logger.js";
+
+/** Every line the PLAN block printed, in order. */
+const planGateLines = () =>
+    (Logger.log as unknown as ReturnType<typeof vi.fn>).mock.calls.map((call) =>
+        String(call[0]),
+    );
 
 describe("copy stories dry-run", () => {
     const sourceAsset = {
@@ -1091,6 +1098,174 @@ describe("copy stories dry-run", () => {
             expect(combined.map((entry) => entry.source_id)).toEqual([1, 2]);
 
             await rm(tempDir, { recursive: true, force: true });
+        });
+
+        const writeStaleLedger = async (manifestRoot: string) => {
+            const manifestDirectory = path.join(
+                manifestRoot,
+                "copy",
+                "source-space",
+                "target-space",
+            );
+
+            await mkdir(manifestDirectory, { recursive: true });
+            await writeFile(
+                path.join(manifestDirectory, "manifest.jsonl"),
+                JSON.stringify({
+                    type: "story",
+                    source_space_id: "source-space",
+                    target_space_id: "target-space",
+                    source_id: 2,
+                    target_id: 5555,
+                    source_uuid: "source-post-uuid",
+                    target_uuid: "stale-target-post-uuid",
+                    source_full_slug: "blog/post-1",
+                    target_full_slug: "imported/blog/post-1",
+                    action: "created",
+                    created_at: "2026-06-23T10:00:00.000Z",
+                }) + "\n",
+                "utf8",
+            );
+        };
+
+        it("plans a create, not a resume, when the mapped target story is gone", async () => {
+            const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
+            const manifestRoot = path.join(tempDir, ".sb-mig");
+
+            await writeStaleLedger(manifestRoot);
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                    manifestRoot,
+                    yes: true,
+                },
+            } as any);
+
+            const lines = planGateLines();
+
+            expect(lines).toContain(
+                "  2 items (1 folder) -> space target-space (2 create, 0 adopt existing, 0 resume from ledger)",
+            );
+            expect(lines).toContain(
+                "    1 ledger mapping no longer resolves in space target-space and will be discarded.",
+            );
+            // And the plan told the truth: both shells really were created.
+            expect(mocks.createStory).toHaveBeenCalledTimes(2);
+
+            await rm(tempDir, { recursive: true, force: true });
+        });
+
+        it("plans an adoption when another story now holds the mapped target path", async () => {
+            stdin.isTTY = true;
+            mocks.askYesNo.mockResolvedValue(false);
+
+            const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
+            const manifestRoot = path.join(tempDir, ".sb-mig");
+            const getStoryBySlug = mocks.getStoryBySlug.getMockImplementation();
+
+            await writeStaleLedger(manifestRoot);
+
+            mocks.getStoryBySlug.mockImplementation(
+                (slug: string, options: any) => {
+                    if (slug === "imported/blog/post-1") {
+                        return Promise.resolve({
+                            story: {
+                                id: 7777,
+                                slug: "post-1",
+                                full_slug: "imported/blog/post-1",
+                                uuid: "other-target-post-uuid",
+                            },
+                        });
+                    }
+
+                    return getStoryBySlug!(slug, options);
+                },
+            );
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                    manifestRoot,
+                },
+            } as any);
+
+            const lines = planGateLines();
+
+            expect(lines).toContain(
+                "  2 items (1 folder) -> space target-space (1 create, 1 adopt existing, 0 resume from ledger)",
+            );
+            expect(lines).toContain(
+                "    1 ledger mapping no longer resolves in space target-space and will be discarded.",
+            );
+            expect(mocks.createStory).not.toHaveBeenCalled();
+
+            await rm(tempDir, { recursive: true, force: true });
+        });
+
+        it("names the stories and field paths that will break before asking", async () => {
+            stdin.isTTY = true;
+            mocks.askYesNo.mockResolvedValue(false);
+            mocks.getAllStories.mockResolvedValue([
+                {
+                    story: {
+                        id: 2,
+                        name: "Post 1",
+                        slug: "post-1",
+                        full_slug: "blog/post-1",
+                        is_folder: false,
+                        parent_id: 1,
+                        uuid: "source-post-uuid",
+                        content: {
+                            component: "page",
+                            cta: {
+                                linktype: "story",
+                                id: 999,
+                            },
+                        },
+                    },
+                },
+            ]);
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                },
+            } as any);
+
+            const lines = planGateLines();
+            const listingIndex = lines.indexOf("    WILL BREAK, by story:");
+
+            expect(listingIndex).toBeGreaterThan(-1);
+            expect(lines[listingIndex - 1]).toContain(
+                "1 leave your selection and WILL BREAK",
+            );
+            expect(lines[listingIndex + 1]).toBe("      blog/post-1");
+            expect(lines[listingIndex + 2]).toContain("-> #999");
+            expect(lines[listingIndex + 2].trim()).toMatch(/^content\.cta/);
+
+            // The detail is on screen before the operator is asked anything.
+            const listingOrder = (
+                Logger.log as unknown as ReturnType<typeof vi.fn>
+            ).mock.invocationCallOrder[listingIndex];
+
+            expect(mocks.askYesNo).toHaveBeenCalledTimes(1);
+            expect(listingOrder).toBeLessThan(
+                mocks.askYesNo.mock.invocationCallOrder[0],
+            );
+            expect(mocks.createStory).not.toHaveBeenCalled();
         });
     });
 

--- a/__tests__/cli/copy-dry-run.test.ts
+++ b/__tests__/cli/copy-dry-run.test.ts
@@ -365,6 +365,58 @@ describe("copy stories dry-run", () => {
         await rm(tempDir, { recursive: true, force: true });
     });
 
+    it("scans only planned stories in children mode, never the excluded root", async () => {
+        const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
+        const outputPath = path.join(tempDir, "plans", "copy-plan.json");
+
+        await copyCommand({
+            input: ["copy", "stories"],
+            flags: {
+                from: "source-space",
+                to: "target-space",
+                source: "blog",
+                mode: "children",
+                destination: "imported",
+                dryRun: true,
+                outputPath,
+            },
+        } as any);
+
+        const report = JSON.parse(await readFile(outputPath, "utf8"));
+
+        expect(report.items).toMatchObject([
+            {
+                type: "story",
+                sourceFullSlug: "blog/post-1",
+                targetFullSlug: "imported/post-1",
+            },
+        ]);
+        // The root folder `blog` is fetched but not copied. Its own cta -> post-1
+        // reference must not be scanned: it would inflate the relink count for
+        // a story this run never writes.
+        expect(
+            report.graph.storyReferences.map(
+                (reference: any) => reference.sourceStoryFullSlug,
+            ),
+        ).toEqual(["blog/post-1", "blog/post-1"]);
+        expect(report.graph.storyReferences).toMatchObject([
+            { path: "parent_id", status: "will_relink" },
+            {
+                path: "content.body.content[0].attrs.uuid",
+                referencedStoryUuid: "source-blog-uuid",
+                status: "will_break",
+            },
+        ]);
+        expect(report.summary).toMatchObject({
+            storyReferences: 2,
+            storyReferencesWillRelink: 1,
+            storyReferencesWillBreak: 1,
+            storyReferencesExternalKept: 0,
+        });
+
+        await rm(tempDir, { recursive: true, force: true });
+    });
+
     it("flags source components missing from the target space during story dry-run", async () => {
         const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
         const outputPath = path.join(tempDir, "plans", "copy-plan.json");

--- a/__tests__/cli/copy-dry-run.test.ts
+++ b/__tests__/cli/copy-dry-run.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
     getStoryById: vi.fn(),
@@ -22,6 +22,11 @@ const mocks = vi.hoisted(() => ({
     createTree: vi.fn(),
     traverseAndCreate: vi.fn(),
     sbApiGet: vi.fn(),
+    askYesNo: vi.fn(),
+}));
+
+vi.mock("../../src/cli/helpers.js", () => ({
+    askYesNo: mocks.askYesNo,
 }));
 
 vi.mock("../../src/cli/api-config.js", () => ({
@@ -908,6 +913,187 @@ describe("copy stories dry-run", () => {
         await rm(tempDir, { recursive: true, force: true });
     });
 
+    describe("plan gate", () => {
+        const stdin = process.stdin as any;
+        const originalIsTTY = stdin.isTTY;
+        const originalExitCode = process.exitCode;
+
+        afterEach(() => {
+            stdin.isTTY = originalIsTTY;
+            process.exitCode = originalExitCode;
+        });
+
+        it("refuses to write without --yes when no terminal can answer", async () => {
+            stdin.isTTY = false;
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                },
+            } as any);
+
+            expect(mocks.askYesNo).not.toHaveBeenCalled();
+            expect(mocks.createStory).not.toHaveBeenCalled();
+            expect(mocks.updateStory).not.toHaveBeenCalled();
+            expect(process.exitCode).toBe(1);
+        });
+
+        it("asks Continue? on a terminal and stops on anything but yes", async () => {
+            stdin.isTTY = true;
+            mocks.askYesNo.mockResolvedValue(false);
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                },
+            } as any);
+
+            expect(mocks.askYesNo).toHaveBeenCalledWith("Continue? [y/N]");
+            expect(mocks.createStory).not.toHaveBeenCalled();
+            expect(process.exitCode).toBe(originalExitCode);
+        });
+
+        it("writes after an explicit yes on a terminal", async () => {
+            stdin.isTTY = true;
+            mocks.askYesNo.mockResolvedValue(true);
+            const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                    manifestRoot: path.join(tempDir, ".sb-mig"),
+                },
+            } as any);
+
+            expect(mocks.askYesNo).toHaveBeenCalledTimes(1);
+            expect(mocks.createStory).toHaveBeenCalledTimes(2);
+
+            await rm(tempDir, { recursive: true, force: true });
+        });
+
+        it("scans references and checks target paths before the gate in apply mode", async () => {
+            stdin.isTTY = false;
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                },
+            } as any);
+
+            // Scanner ran (component schemas fetched) and every planned
+            // target path was checked for adoption, all before any write.
+            expect(mocks.getAllComponents).toHaveBeenCalledWith(
+                expect.objectContaining({ spaceId: "source-space" }),
+            );
+            expect(mocks.getStoryBySlug).toHaveBeenCalledWith(
+                "imported/blog/post-1",
+                expect.objectContaining({ spaceId: "target-space" }),
+            );
+            expect(mocks.createStory).not.toHaveBeenCalled();
+        });
+
+        it("moves the existing ledger aside with --fresh and starts empty", async () => {
+            const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
+            const manifestRoot = path.join(tempDir, ".sb-mig");
+            const manifestDirectory = path.join(
+                manifestRoot,
+                "copy",
+                "source-space",
+                "target-space",
+            );
+            const staleEntry = {
+                type: "story",
+                source_space_id: "source-space",
+                target_space_id: "target-space",
+                source_id: 2,
+                target_id: 5555,
+                source_uuid: "source-post-uuid",
+                target_uuid: "stale-target-post-uuid",
+                source_full_slug: "blog/post-1",
+                target_full_slug: "imported/blog/post-1",
+                action: "created",
+                created_at: "2026-06-23T10:00:00.000Z",
+            };
+
+            await mkdir(manifestDirectory, { recursive: true });
+            await writeFile(
+                path.join(manifestDirectory, "manifest.jsonl"),
+                JSON.stringify(staleEntry) + "\n",
+                "utf8",
+            );
+            await writeFile(
+                path.join(manifestDirectory, "stories.manifest.jsonl"),
+                JSON.stringify(staleEntry) + "\n",
+                "utf8",
+            );
+
+            await copyCommand({
+                input: ["copy", "stories"],
+                flags: {
+                    from: "source-space",
+                    to: "target-space",
+                    source: "blog",
+                    destination: "imported",
+                    manifestRoot,
+                    fresh: true,
+                    yes: true,
+                },
+            } as any);
+
+            // The stale mapping was not reused: both shells were created anew.
+            expect(mocks.createStory).toHaveBeenCalledTimes(2);
+            expect(mocks.getStoryById).not.toHaveBeenCalledWith(
+                "5555",
+                expect.anything(),
+            );
+
+            const { readdir } = await import("fs/promises");
+            const files = (await readdir(manifestDirectory)).sort();
+
+            expect(
+                files.filter((file) => /^manifest\.jsonl\..+\.bak$/.test(file)),
+            ).toHaveLength(1);
+            expect(
+                files.filter((file) =>
+                    /^stories\.manifest\.jsonl\..+\.bak$/.test(file),
+                ),
+            ).toHaveLength(1);
+
+            const combined = (
+                await readFile(
+                    path.join(manifestDirectory, "manifest.jsonl"),
+                    "utf8",
+                )
+            )
+                .trim()
+                .split("\n")
+                .map((line) => JSON.parse(line));
+
+            expect(combined.every((entry) => entry.target_id !== 5555)).toBe(
+                true,
+            );
+            expect(combined.map((entry) => entry.source_id)).toEqual([1, 2]);
+
+            await rm(tempDir, { recursive: true, force: true });
+        });
+    });
+
     it("copies selected stories and writes story manifests", async () => {
         const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-copy-"));
         const manifestRoot = path.join(tempDir, ".sb-mig");
@@ -944,6 +1130,7 @@ describe("copy stories dry-run", () => {
                 source: "blog",
                 destination: "imported",
                 manifestRoot,
+                yes: true,
             },
         } as any);
 
@@ -1144,6 +1331,7 @@ describe("copy stories dry-run", () => {
                 source: "plain",
                 destination: "imported",
                 manifestRoot,
+                yes: true,
             },
         } as any);
 
@@ -1244,6 +1432,7 @@ describe("copy stories dry-run", () => {
                 destination: "imported",
                 publicationLanguages: "default",
                 manifestRoot,
+                yes: true,
             },
         } as any);
 
@@ -1340,6 +1529,7 @@ describe("copy stories dry-run", () => {
                 destination: "imported",
                 publicationMode: "save-only",
                 manifestRoot,
+                yes: true,
             },
         } as any);
 
@@ -1434,6 +1624,7 @@ describe("copy stories dry-run", () => {
                 destination: "imported",
                 publicationLanguages: "default",
                 manifestRoot,
+                yes: true,
             },
         } as any);
 
@@ -1507,6 +1698,7 @@ describe("copy stories dry-run", () => {
                     source: "blog",
                     destination: "imported",
                     manifestRoot,
+                    yes: true,
                 },
             } as any),
         ).rejects.toThrow(
@@ -1540,6 +1732,7 @@ describe("copy stories dry-run", () => {
                     source: "blog",
                     destination: "imported",
                     manifestRoot,
+                    yes: true,
                 },
             } as any),
         ).rejects.toThrow(
@@ -1620,6 +1813,7 @@ describe("copy stories dry-run", () => {
                 source: "blog",
                 destination: "imported",
                 manifestRoot,
+                yes: true,
             },
         } as any);
 
@@ -1716,6 +1910,7 @@ describe("copy stories dry-run", () => {
                 source: "blog",
                 destination: "imported",
                 manifestRoot,
+                yes: true,
             },
         } as any);
 
@@ -1789,6 +1984,7 @@ describe("copy stories dry-run", () => {
                 withAssets: true,
                 manifestRoot,
                 outputPath,
+                yes: true,
             },
         } as any);
 

--- a/__tests__/cli/copy-relink.test.ts
+++ b/__tests__/cli/copy-relink.test.ts
@@ -1,0 +1,378 @@
+import { mkdtemp, readFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    getStoryById: vi.fn(),
+    getStoryBySlug: vi.fn(),
+    getAllStories: vi.fn(),
+    createStory: vi.fn(),
+    updateStory: vi.fn(),
+    getAllComponents: vi.fn(),
+    createTree: vi.fn(),
+    traverseAndCreate: vi.fn(),
+    sbApiGet: vi.fn(),
+    askYesNo: vi.fn(),
+}));
+
+vi.mock("../../src/cli/helpers.js", () => ({
+    askYesNo: mocks.askYesNo,
+}));
+
+vi.mock("../../src/cli/api-config.js", () => ({
+    apiConfig: {
+        spaceId: "default-space",
+        sbApi: {
+            get: mocks.sbApiGet,
+        },
+    },
+}));
+
+vi.mock("../../src/api/managementApi.js", () => ({
+    managementApi: {
+        stories: {
+            getStoryById: mocks.getStoryById,
+            getStoryBySlug: mocks.getStoryBySlug,
+            getAllStories: mocks.getAllStories,
+            createStory: mocks.createStory,
+            updateStory: mocks.updateStory,
+        },
+        components: {
+            getAllComponents: mocks.getAllComponents,
+        },
+        assets: {},
+    },
+}));
+
+vi.mock("../../src/api/stories/tree.js", () => ({
+    createTree: mocks.createTree,
+    traverseAndCreate: mocks.traverseAndCreate,
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+    default: {
+        log: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+import { copyCommand } from "../../src/cli/commands/copy.js";
+import Logger from "../../src/utils/logger.js";
+
+const planLines = () =>
+    (Logger.log as unknown as ReturnType<typeof vi.fn>).mock.calls.map((call) =>
+        String(call[0]),
+    );
+
+/** The reference the copy left behind: still the SOURCE folder's uuid and id. */
+const brokenTargetContent = () => ({
+    component: "page",
+    cta: {
+        linktype: "story",
+        id: 1,
+        uuid: "source-blog-uuid",
+    },
+});
+
+/** The same field after a healthy copy: the target folder's uuid and id. */
+const repairedTargetContent = () => ({
+    component: "page",
+    cta: {
+        linktype: "story",
+        id: 1001,
+        uuid: "target-blog-uuid",
+    },
+});
+
+const sourceFolder = {
+    id: 1,
+    name: "Blog",
+    slug: "blog",
+    full_slug: "blog",
+    is_folder: true,
+    parent_id: 0,
+    uuid: "source-blog-uuid",
+    content: { component: "page" },
+};
+
+const sourcePost = {
+    id: 2,
+    name: "Post 1",
+    slug: "post-1",
+    full_slug: "blog/post-1",
+    is_folder: false,
+    parent_id: 1,
+    uuid: "source-post-uuid",
+    content: brokenTargetContent(),
+};
+
+const targetFolder = {
+    id: 1001,
+    name: "Blog",
+    slug: "blog",
+    full_slug: "imported/blog",
+    is_folder: true,
+    uuid: "target-blog-uuid",
+};
+
+const relinkFlags = (extra: Record<string, unknown> = {}) => ({
+    input: ["copy", "relink"],
+    flags: {
+        from: "source-space",
+        to: "target-space",
+        source: "blog",
+        destination: "imported",
+        ...extra,
+    },
+});
+
+describe("copy relink", () => {
+    const stdin = process.stdin as any;
+    const originalIsTTY = stdin.isTTY;
+    const originalExitCode = process.exitCode;
+    let targetPost: any;
+
+    afterEach(() => {
+        stdin.isTTY = originalIsTTY;
+        process.exitCode = originalExitCode;
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        stdin.isTTY = false;
+
+        targetPost = {
+            id: 1002,
+            name: "Post 1",
+            slug: "post-1",
+            full_slug: "imported/blog/post-1",
+            is_folder: false,
+            uuid: "target-post-uuid",
+            published: false,
+            content: brokenTargetContent(),
+        };
+
+        mocks.getStoryById.mockResolvedValue(undefined);
+        mocks.getStoryBySlug.mockImplementation((slug: string) => {
+            const stories: Record<string, any> = {
+                blog: sourceFolder,
+                imported: {
+                    id: 900,
+                    slug: "imported",
+                    full_slug: "imported",
+                    is_folder: true,
+                    uuid: "target-imported-uuid",
+                },
+                "imported/blog": targetFolder,
+                "imported/blog/post-1": targetPost,
+            };
+
+            return Promise.resolve(
+                stories[slug] ? { story: stories[slug] } : undefined,
+            );
+        });
+        mocks.getAllStories.mockResolvedValue([{ story: sourcePost }]);
+        mocks.createTree.mockImplementation((stories: any[]) => [
+            {
+                id: stories[0].id,
+                story: stories[0],
+                children: [
+                    {
+                        id: stories[1].id,
+                        story: stories[1],
+                        children: [],
+                    },
+                ],
+            },
+        ]);
+        mocks.getAllComponents.mockResolvedValue([
+            {
+                name: "page",
+                schema: {
+                    cta: { type: "multilink" },
+                },
+            },
+        ]);
+        mocks.updateStory.mockResolvedValue({ ok: true });
+    });
+
+    it("rebuilds the mapping from the target space and repairs the reference", async () => {
+        const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-relink-"));
+        const manifestRoot = path.join(tempDir, ".sb-mig");
+
+        await copyCommand(
+            relinkFlags({ manifestRoot, yes: true }) as any,
+        );
+
+        // Nothing was created and nothing was copied from the source: one
+        // story updated, carrying only the remapped reference.
+        expect(mocks.createStory).not.toHaveBeenCalled();
+        expect(mocks.updateStory).toHaveBeenCalledTimes(1);
+
+        const [payload, storyId, options] = mocks.updateStory.mock.calls[0];
+
+        expect(storyId).toBe("1002");
+        expect(options).toMatchObject({ publish: false, force_update: true });
+        expect(payload).toMatchObject({
+            id: 1002,
+            name: "Post 1",
+            slug: "post-1",
+            content: repairedTargetContent(),
+        });
+
+        // Both target stories were adopted into the ledger before the rewrite.
+        const manifest = (
+            await readFile(
+                path.join(
+                    manifestRoot,
+                    "copy",
+                    "source-space",
+                    "target-space",
+                    "manifest.jsonl",
+                ),
+                "utf8",
+            )
+        )
+            .trim()
+            .split("\n")
+            .map((line) => JSON.parse(line));
+
+        expect(manifest).toMatchObject([
+            {
+                source_id: 1,
+                target_id: 1001,
+                source_uuid: "source-blog-uuid",
+                target_uuid: "target-blog-uuid",
+                action: "matched_by_target_key",
+            },
+            {
+                source_id: 2,
+                target_id: 1002,
+                source_uuid: "source-post-uuid",
+                target_uuid: "target-post-uuid",
+                action: "matched_by_target_key",
+            },
+        ]);
+
+        await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("leaves a story whose references already resolve untouched", async () => {
+        const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-relink-"));
+
+        targetPost.content = repairedTargetContent();
+
+        await copyCommand(
+            relinkFlags({
+                manifestRoot: path.join(tempDir, ".sb-mig"),
+                yes: true,
+            }) as any,
+        );
+
+        expect(mocks.updateStory).not.toHaveBeenCalled();
+        expect(planLines()).toContain(
+            "  rewrite: 0 references in 0 stories; 1 already correct and left untouched",
+        );
+
+        await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("states the exact rewrite before asking, and refuses to write without an answer", async () => {
+        const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-relink-"));
+        const manifestRoot = path.join(tempDir, ".sb-mig");
+
+        await copyCommand(relinkFlags({ manifestRoot }) as any);
+
+        const lines = planLines();
+
+        expect(lines).toContain(
+            "  2 planned items (1 folder) in space target-space (0 mapped by ledger, 2 adopted by target path, 0 missing from target)",
+        );
+        expect(lines).toContain(
+            "  rewrite: 2 references in 1 story; 0 already correct and left untouched",
+        );
+        expect(lines).toContain(
+            "  content: only reference values change; nothing is copied from the source",
+        );
+        expect(mocks.updateStory).not.toHaveBeenCalled();
+        expect(process.exitCode).toBe(1);
+        // The gate refused before anything was recorded in the ledger.
+        await expect(
+            readFile(
+                path.join(
+                    manifestRoot,
+                    "copy",
+                    "source-space",
+                    "target-space",
+                    "manifest.jsonl",
+                ),
+                "utf8",
+            ),
+        ).rejects.toThrow();
+
+        await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("previews without touching Storyblok or the ledger on --dry-run", async () => {
+        const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-relink-"));
+        const manifestRoot = path.join(tempDir, ".sb-mig");
+
+        await copyCommand(
+            relinkFlags({ manifestRoot, dryRun: true }) as any,
+        );
+
+        expect(planLines()).toContain(
+            "  rewrite: 2 references in 1 story; 0 already correct and left untouched",
+        );
+        expect(mocks.askYesNo).not.toHaveBeenCalled();
+        expect(mocks.updateStory).not.toHaveBeenCalled();
+        await expect(
+            readFile(
+                path.join(
+                    manifestRoot,
+                    "copy",
+                    "source-space",
+                    "target-space",
+                    "manifest.jsonl",
+                ),
+                "utf8",
+            ),
+        ).rejects.toThrow();
+
+        await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("reports planned stories that are not in the target at all", async () => {
+        const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-relink-"));
+
+        mocks.getStoryBySlug.mockImplementation((slug: string) => {
+            const stories: Record<string, any> = {
+                blog: sourceFolder,
+                imported: { id: 900, slug: "imported", full_slug: "imported" },
+                "imported/blog": targetFolder,
+            };
+
+            return Promise.resolve(
+                stories[slug] ? { story: stories[slug] } : undefined,
+            );
+        });
+
+        await copyCommand(
+            relinkFlags({
+                manifestRoot: path.join(tempDir, ".sb-mig"),
+                yes: true,
+            }) as any,
+        );
+
+        expect(planLines()).toContain(
+            "    1 planned story is not in the target and cannot be relinked; copy it first.",
+        );
+        expect(mocks.updateStory).not.toHaveBeenCalled();
+
+        await rm(tempDir, { recursive: true, force: true });
+    });
+});

--- a/__tests__/cli/copy-relink.test.ts
+++ b/__tests__/cli/copy-relink.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 
@@ -119,6 +119,27 @@ const targetFolder = {
     uuid: "target-blog-uuid",
 };
 
+/** Writes a ledger the run will read back, the way an earlier copy left it. */
+const writeLedger = async (manifestRoot: string, entries: unknown[]) => {
+    const dir = path.join(manifestRoot, "copy", "source-space", "target-space");
+
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+        path.join(dir, "manifest.jsonl"),
+        entries.map((entry) => JSON.stringify(entry)).join("\n") + "\n",
+        "utf8",
+    );
+};
+
+const storyLedgerEntry = (entry: Record<string, unknown>) => ({
+    type: "story",
+    source_space_id: "source-space",
+    target_space_id: "target-space",
+    action: "created",
+    created_at: "2026-09-03T00:00:00.000Z",
+    ...entry,
+});
+
 const relinkFlags = (extra: Record<string, unknown> = {}) => ({
     input: ["copy", "relink"],
     flags: {
@@ -204,9 +225,7 @@ describe("copy relink", () => {
         const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-relink-"));
         const manifestRoot = path.join(tempDir, ".sb-mig");
 
-        await copyCommand(
-            relinkFlags({ manifestRoot, yes: true }) as any,
-        );
+        await copyCommand(relinkFlags({ manifestRoot, yes: true }) as any);
 
         // Nothing was created and nothing was copied from the source: one
         // story updated, carrying only the remapped reference.
@@ -321,9 +340,7 @@ describe("copy relink", () => {
         const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-relink-"));
         const manifestRoot = path.join(tempDir, ".sb-mig");
 
-        await copyCommand(
-            relinkFlags({ manifestRoot, dryRun: true }) as any,
-        );
+        await copyCommand(relinkFlags({ manifestRoot, dryRun: true }) as any);
 
         expect(planLines()).toContain(
             "  rewrite: 2 references in 1 story; 0 already correct and left untouched",
@@ -342,6 +359,233 @@ describe("copy relink", () => {
                 "utf8",
             ),
         ).rejects.toThrow();
+
+        await rm(tempDir, { recursive: true, force: true });
+    });
+
+    /**
+     * The state a half-finished copy really leaves behind: the ledger still
+     * maps a story whose target has since been deleted, and a story that IS in
+     * the target still references it.
+     */
+    const setUpStaleLedgerMapping = async (manifestRoot: string) => {
+        const sourceReferencingPost = {
+            ...sourcePost,
+            content: {
+                component: "page",
+                cta: { linktype: "story", id: 3, uuid: "source-post-3-uuid" },
+            },
+        };
+        const sourceDeletedPost = {
+            id: 3,
+            name: "Post 3",
+            slug: "post-3",
+            full_slug: "blog/post-3",
+            is_folder: false,
+            parent_id: 1,
+            uuid: "source-post-3-uuid",
+            content: { component: "page" },
+        };
+
+        targetPost.content = {
+            component: "page",
+            cta: { linktype: "story", id: 3, uuid: "source-post-3-uuid" },
+        };
+
+        await writeLedger(manifestRoot, [
+            storyLedgerEntry({
+                source_id: 3,
+                target_id: 3003,
+                source_uuid: "source-post-3-uuid",
+                target_uuid: "deleted-target-uuid",
+                source_full_slug: "blog/post-3",
+                target_full_slug: "imported/blog/post-3",
+            }),
+        ]);
+
+        mocks.getAllStories.mockResolvedValue([
+            { story: sourceReferencingPost },
+            { story: sourceDeletedPost },
+        ]);
+        mocks.createTree.mockImplementation((stories: any[]) => [
+            {
+                id: stories[0].id,
+                story: stories[0],
+                children: stories.slice(1).map((story: any) => ({
+                    id: story.id,
+                    story,
+                    children: [],
+                })),
+            },
+        ]);
+        // The mapped target story was deleted, and no story lives at its path.
+        mocks.getStoryById.mockResolvedValue(undefined);
+    };
+
+    it("never rewrites a reference through a ledger mapping whose target is gone", async () => {
+        const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-relink-"));
+        const manifestRoot = path.join(tempDir, ".sb-mig");
+
+        await setUpStaleLedgerMapping(manifestRoot);
+
+        await copyCommand(relinkFlags({ manifestRoot, yes: true }) as any);
+
+        // Leaving the broken reference alone is the correct outcome: pointing
+        // it at the deleted story would be worse than the break.
+        expect(mocks.updateStory).not.toHaveBeenCalled();
+        expect(JSON.stringify(mocks.updateStory.mock.calls)).not.toContain(
+            "deleted-target-uuid",
+        );
+
+        await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("classifies references into a story missing from the target as breaks", async () => {
+        const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-relink-"));
+        const manifestRoot = path.join(tempDir, ".sb-mig");
+
+        await setUpStaleLedgerMapping(manifestRoot);
+
+        await copyCommand(relinkFlags({ manifestRoot, dryRun: true }) as any);
+
+        const lines = planLines();
+
+        expect(lines).toContain(
+            "    1 planned story is not in the target and cannot be relinked; copy it first.",
+        );
+        expect(lines).toContain(
+            "  source references: 2 will relink, 1 leave your selection and WILL BREAK",
+        );
+        expect(lines).toContain(
+            "    References into the story missing from the target cannot be repaired here; copy it first, then relink again.",
+        );
+        // The shared ledger line must not offer a flag this command lacks.
+        expect(
+            lines.some((line) => line.includes("use --fresh to ignore")),
+        ).toBe(false);
+
+        await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("repairs references into stories outside the selection when the mapping still resolves", async () => {
+        const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-relink-"));
+        const manifestRoot = path.join(tempDir, ".sb-mig");
+
+        targetPost.content = {
+            component: "page",
+            cta: { linktype: "story", id: 5, uuid: "shared-header-uuid" },
+        };
+
+        await writeLedger(manifestRoot, [
+            storyLedgerEntry({
+                source_id: 5,
+                target_id: 5005,
+                source_uuid: "shared-header-uuid",
+                target_uuid: "target-header-uuid",
+                source_full_slug: "shared/header",
+                target_full_slug: "imported/shared/header",
+            }),
+        ]);
+        mocks.getStoryById.mockImplementation((storyId: string) =>
+            Promise.resolve(
+                storyId === "5005"
+                    ? { story: { id: 5005, uuid: "target-header-uuid" } }
+                    : undefined,
+            ),
+        );
+
+        await copyCommand(relinkFlags({ manifestRoot, yes: true }) as any);
+
+        expect(mocks.updateStory).toHaveBeenCalledTimes(1);
+        expect(mocks.updateStory.mock.calls[0][0]).toMatchObject({
+            content: {
+                cta: { id: 5005, uuid: "target-header-uuid" },
+            },
+        });
+
+        await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("does not call a reference broken when the ledger already covers it", async () => {
+        const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-relink-"));
+        const manifestRoot = path.join(tempDir, ".sb-mig");
+
+        // The source story links to a story outside this selection; the target
+        // copy of it already points at the right story. Nothing to repair, and
+        // nothing to shout about: the ledger covers the reference.
+        mocks.getAllStories.mockResolvedValue([
+            {
+                story: {
+                    ...sourcePost,
+                    content: {
+                        component: "page",
+                        cta: {
+                            linktype: "story",
+                            id: 5,
+                            uuid: "shared-header-uuid",
+                        },
+                    },
+                },
+            },
+        ]);
+        targetPost.content = {
+            component: "page",
+            cta: {
+                linktype: "story",
+                id: 5005,
+                uuid: "target-header-uuid",
+            },
+        };
+
+        await writeLedger(manifestRoot, [
+            storyLedgerEntry({
+                source_id: 5,
+                target_id: 5005,
+                source_uuid: "shared-header-uuid",
+                target_uuid: "target-header-uuid",
+                source_full_slug: "shared/header",
+                target_full_slug: "imported/shared/header",
+            }),
+        ]);
+
+        await copyCommand(relinkFlags({ manifestRoot, dryRun: true }) as any);
+
+        const lines = planLines();
+
+        expect(lines).toContain(
+            "  source references: 2 will relink, 0 will break",
+        );
+        expect(lines.some((line) => line.includes("WILL BREAK"))).toBe(false);
+        expect(mocks.updateStory).not.toHaveBeenCalled();
+
+        await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("drops an out-of-selection ledger mapping whose target story is gone", async () => {
+        const tempDir = await mkdtemp(path.join(tmpdir(), "sb-mig-relink-"));
+        const manifestRoot = path.join(tempDir, ".sb-mig");
+
+        targetPost.content = {
+            component: "page",
+            cta: { linktype: "story", id: 5, uuid: "shared-header-uuid" },
+        };
+
+        await writeLedger(manifestRoot, [
+            storyLedgerEntry({
+                source_id: 5,
+                target_id: 5005,
+                source_uuid: "shared-header-uuid",
+                target_uuid: "target-header-uuid",
+                source_full_slug: "shared/header",
+                target_full_slug: "imported/shared/header",
+            }),
+        ]);
+        // The mapped story is no longer in the target space.
+        mocks.getStoryById.mockResolvedValue(undefined);
+
+        await copyCommand(relinkFlags({ manifestRoot, yes: true }) as any);
+
+        expect(mocks.updateStory).not.toHaveBeenCalled();
 
         await rm(tempDir, { recursive: true, force: true });
     });

--- a/__tests__/cli/help-output.test.ts
+++ b/__tests__/cli/help-output.test.ts
@@ -115,6 +115,8 @@ describe("CLI help output", () => {
 
         expect(copyHelp).toContain("copy stories");
         expect(copyHelp).toContain("copy assets");
+        expect(copyHelp).toContain("copy relink");
+        expect(copyHelp).toContain("matched_by_target_key");
         expect(copyHelp).toContain("--source");
         expect(copyHelp).toContain("--destination");
         expect(copyHelp).toContain("--mode");

--- a/__tests__/cli/help-output.test.ts
+++ b/__tests__/cli/help-output.test.ts
@@ -120,6 +120,9 @@ describe("CLI help output", () => {
         expect(copyHelp).toContain("--mode");
         expect(copyHelp).toContain("--all");
         expect(copyHelp).toContain("--dry-run");
+        expect(copyHelp).toContain("--yes");
+        expect(copyHelp).toContain("--fresh");
+        expect(copyHelp).toContain("PLAN block");
         expect(copyHelp).toContain("--outputPath");
         expect(copyHelp).toContain("folder/*");
         expect(copyHelp).toContain("durable manifests");

--- a/docs/copy-command-spec.md
+++ b/docs/copy-command-spec.md
@@ -334,8 +334,6 @@ Known fields to rewrite:
 | `options` with `source: "internal_stories"` | story ids  | Replace each source id with target id            |
 | nested `bloks`                              | varies     | Recursively inspect nested components            |
 | richtext embedded bloks                     | varies     | Recursively inspect embedded component content   |
-| `alternates[].id`                           | story id   | Replace source id with target id                 |
-| `alternates[].parent_id`                    | story id   | Replace source parent id with target parent id   |
 | `parent_id`                                 | story id   | Replace source parent id with target parent id   |
 
 If a story reference points to a story outside the selected copy scope, the command must not silently corrupt it. Every scanned story reference in the copy graph (`graph.storyReferences[].status`) is classified against the copy plan **and** the ledger:

--- a/docs/copy-command-spec.md
+++ b/docs/copy-command-spec.md
@@ -338,11 +338,24 @@ Known fields to rewrite:
 | `alternates[].parent_id`                    | story id   | Replace source parent id with target parent id   |
 | `parent_id`                                 | story id   | Replace source parent id with target parent id   |
 
-If a story reference points to a story outside the selected copy scope, the command must not silently corrupt it. The copy report should classify it:
+If a story reference points to a story outside the selected copy scope, the command must not silently corrupt it. Every scanned story reference in the copy graph (`graph.storyReferences[].status`) is classified against the copy plan **and** the ledger:
 
-- `preserved_external_reference`
-- `unresolved_story_reference`
-- `skipped_reference_rewrite`
+| Status          | Meaning                                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `unclassified`  | Emitted by the scanner, which sees one story at a time and cannot know the plan. Replaced before the graph is reported. |
+| `will_relink`   | The referenced story is inside the selection (its mapping exists by phase 2) or is already in the loaded ledger.        |
+| `will_break`    | The referenced story is outside the selection and not in the ledger; in a cross-space copy this reference dangles.      |
+| `external_kept` | Same-space copy, where continuing to point at the original story is correct.                                            |
+| `unresolved`    | Reference policy `fail`: the reference cannot be handled.                                                               |
+| `unsupported`   | The reference shape is not rewritable.                                                                                  |
+
+Notes:
+
+- `parent_id` is resolved by the copy plan itself — phase 1 creates every shell under its planned parent, and the top of the selection lands under the destination — so it is always `will_relink` and never reported as a break.
+- `parent_id: 0` is Storyblok's "lives at the space root" sentinel, not a story id, and is not recorded as a reference at all.
+- When `will_break > 0` the dry-run prints a loud report naming each holding story and field path, and the graph carries a `broken_story_reference` warning per story.
+
+The dry-run summary exposes the same accounting as `storyReferencesWillRelink`, `storyReferencesWillBreak`, `storyReferencesExternalKept` and `storyReferencesUnresolved`.
 
 Potential policies:
 

--- a/src/api/copy/index.ts
+++ b/src/api/copy/index.ts
@@ -1,5 +1,6 @@
 export * from "./graph.js";
 export * from "./manifest.js";
+export * from "./plan-gate.js";
 export * from "./reference-classifier.js";
 export * from "./reference-scanner.js";
 export * from "./reference-rewriter.js";

--- a/src/api/copy/index.ts
+++ b/src/api/copy/index.ts
@@ -1,5 +1,6 @@
 export * from "./graph.js";
 export * from "./manifest.js";
+export * from "./reference-classifier.js";
 export * from "./reference-scanner.js";
 export * from "./reference-rewriter.js";
 export * from "./assets.js";

--- a/src/api/copy/index.ts
+++ b/src/api/copy/index.ts
@@ -1,6 +1,7 @@
 export * from "./graph.js";
 export * from "./manifest.js";
 export * from "./plan-gate.js";
+export * from "./relink.js";
 export * from "./reference-classifier.js";
 export * from "./reference-scanner.js";
 export * from "./reference-rewriter.js";

--- a/src/api/copy/manifest.ts
+++ b/src/api/copy/manifest.ts
@@ -39,6 +39,39 @@ export const getDefaultCopyManifestPaths = ({
     };
 };
 
+/**
+ * Moves every existing manifest file of a copy pair aside so the next run
+ * starts with an empty ledger. Nothing is deleted: each file is renamed with
+ * a timestamp suffix next to the original. Returns the archived paths.
+ */
+export const archiveCopyManifests = async (
+    paths: CopyManifestPaths,
+    now: Date = new Date(),
+): Promise<string[]> => {
+    const suffix = now.toISOString().replace(/[:.]/g, "-");
+    const archived: string[] = [];
+
+    for (const filePath of [
+        paths.combined,
+        paths.stories,
+        paths.assets,
+        paths.assetFolders,
+    ]) {
+        const archivePath = `${filePath}.${suffix}.bak`;
+
+        try {
+            await fs.rename(filePath, archivePath);
+            archived.push(archivePath);
+        } catch (error: any) {
+            if (error?.code !== "ENOENT") {
+                throw error;
+            }
+        }
+    }
+
+    return archived;
+};
+
 export const createEmptyCopyMaps = (): CopyMaps => ({
     storyIds: new Map(),
     storyUuids: new Map(),

--- a/src/api/copy/plan-gate.ts
+++ b/src/api/copy/plan-gate.ts
@@ -36,6 +36,17 @@ export type CopyPlanGateLedger = {
     ignored: boolean;
 };
 
+/** The reference facts a PLAN block states, whatever command printed it. */
+export type CopyPlanGateReferences = {
+    scanned: boolean;
+    total: number;
+    willRelink: number;
+    willBreak: number;
+    externalKept: number;
+    /** The will-break references grouped by the story that holds them. */
+    breaking: CopyBrokenStoryReferenceGroup[];
+};
+
 export type CopyPlanGateSummary = {
     sourceSpaceId: string;
     targetSpaceId: string;
@@ -60,15 +71,7 @@ export type CopyPlanGateSummary = {
         staleLedger: number;
     };
     ledger: CopyPlanGateLedger;
-    references: {
-        scanned: boolean;
-        total: number;
-        willRelink: number;
-        willBreak: number;
-        externalKept: number;
-        /** The will-break references grouped by the story that holds them. */
-        breaking: CopyBrokenStoryReferenceGroup[];
-    };
+    references: CopyPlanGateReferences;
     assets?: {
         toCopy: number;
         mapped: number;
@@ -189,37 +192,13 @@ export const formatCopyPlanGate = (summary: CopyPlanGateSummary): string[] => {
         );
     }
 
-    if (ledger.ignored) {
-        lines.push(
-            `  ledger: ${ledger.entries} ${plural(ledger.entries, "entry", "entries")} at ${ledger.path} IGNORED (--fresh; starting empty)`,
-        );
-    } else if (ledger.entries > 0) {
-        lines.push(
-            `  ledger: ${ledger.entries} ${plural(ledger.entries, "entry", "entries")} loaded from ${ledger.path} (resuming; use --fresh to ignore)`,
-        );
-    } else {
-        lines.push(`  ledger: none at ${ledger.path} (starting empty)`);
-    }
-
-    if (!references.scanned) {
-        lines.push("  references: not scanned");
-    } else {
-        const referenceParts = [`${references.willRelink} will relink`];
-
-        if (summary.sameSpace) {
-            referenceParts.push(
-                `${references.externalKept} outside the selection kept (same space)`,
-            );
-        }
-
-        referenceParts.push(
-            references.willBreak > 0
-                ? `${references.willBreak} leave your selection and WILL BREAK`
-                : "0 will break",
-        );
-        lines.push(`  references: ${referenceParts.join(", ")}`);
-        lines.push(...formatBreakingReferences(references.breaking));
-    }
+    lines.push(formatCopyPlanGateLedger(ledger));
+    lines.push(
+        ...formatCopyPlanGateReferences({
+            references,
+            sameSpace: summary.sameSpace,
+        }),
+    );
 
     if (assets) {
         lines.push(
@@ -230,6 +209,53 @@ export const formatCopyPlanGate = (summary: CopyPlanGateSummary): string[] => {
     }
 
     return lines;
+};
+
+/** The one line stating where the ledger came from and whether it is used. */
+export const formatCopyPlanGateLedger = (
+    ledger: CopyPlanGateLedger,
+): string => {
+    if (ledger.ignored) {
+        return `  ledger: ${ledger.entries} ${plural(ledger.entries, "entry", "entries")} at ${ledger.path} IGNORED (--fresh; starting empty)`;
+    }
+
+    if (ledger.entries > 0) {
+        return `  ledger: ${ledger.entries} ${plural(ledger.entries, "entry", "entries")} loaded from ${ledger.path} (resuming; use --fresh to ignore)`;
+    }
+
+    return `  ledger: none at ${ledger.path} (starting empty)`;
+};
+
+/** The reference counts and, when anything dangles, the grouped detail. */
+export const formatCopyPlanGateReferences = ({
+    references,
+    sameSpace,
+}: {
+    references: CopyPlanGateReferences;
+    sameSpace: boolean;
+}): string[] => {
+    if (!references.scanned) {
+        return ["  references: not scanned"];
+    }
+
+    const parts = [`${references.willRelink} will relink`];
+
+    if (sameSpace) {
+        parts.push(
+            `${references.externalKept} outside the selection kept (same space)`,
+        );
+    }
+
+    parts.push(
+        references.willBreak > 0
+            ? `${references.willBreak} leave your selection and WILL BREAK`
+            : "0 will break",
+    );
+
+    return [
+        `  references: ${parts.join(", ")}`,
+        ...formatBreakingReferences(references.breaking),
+    ];
 };
 
 /**

--- a/src/api/copy/plan-gate.ts
+++ b/src/api/copy/plan-gate.ts
@@ -1,0 +1,199 @@
+import type { CopyGraph, CopyMaps } from "./types.js";
+
+import { countStoryReferenceStatuses } from "./reference-classifier.js";
+
+/**
+ * Everything a `copy stories` apply run knows before its first write, in one
+ * place. Built from the plan, the target conflict check, the loaded ledger and
+ * the reference scan so the PLAN block can be rendered and tested without any
+ * API access.
+ */
+export type CopyPlanGatePlanItem = {
+    type: "folder" | "story";
+    sourceId?: number;
+    sourceFullSlug: string;
+    targetFullSlug: string;
+};
+
+export type CopyPlanGateLedger = {
+    /** Absolute path of the combined manifest the run reads back. */
+    path: string;
+    /** Entries found on disk, whether or not they are used. */
+    entries: number;
+    /** `--fresh`: the entries above are ignored and the run starts empty. */
+    ignored: boolean;
+};
+
+export type CopyPlanGateSummary = {
+    sourceSpaceId: string;
+    targetSpaceId: string;
+    sameSpace: boolean;
+    stories: {
+        total: number;
+        folders: number;
+        /** No ledger mapping and no existing target path: a new shell. */
+        create: number;
+        /** Ledger already maps the source story: the mapped target is reused. */
+        resume: number;
+        /**
+         * No ledger mapping but the target path already exists: the run adopts
+         * it (`matched_by_target_key`) and UPDATES it in place.
+         */
+        adopt: number;
+    };
+    ledger: CopyPlanGateLedger;
+    references: {
+        scanned: boolean;
+        total: number;
+        willRelink: number;
+        willBreak: number;
+        externalKept: number;
+    };
+    assets?: {
+        toCopy: number;
+        mapped: number;
+    };
+};
+
+export const buildCopyPlanGateSummary = ({
+    sourceSpaceId,
+    targetSpaceId,
+    plan,
+    conflictTargetFullSlugs,
+    copyMaps,
+    ledger,
+    graph,
+    withAssets,
+}: {
+    sourceSpaceId: string;
+    targetSpaceId: string;
+    plan: CopyPlanGatePlanItem[];
+    conflictTargetFullSlugs: Iterable<string>;
+    copyMaps: CopyMaps;
+    ledger: CopyPlanGateLedger;
+    graph?: CopyGraph;
+    withAssets: boolean;
+}): CopyPlanGateSummary => {
+    const conflicts = new Set(conflictTargetFullSlugs);
+    let create = 0;
+    let resume = 0;
+    let adopt = 0;
+
+    for (const item of plan) {
+        if (
+            item.sourceId !== undefined &&
+            copyMaps.storyIds.has(item.sourceId)
+        ) {
+            resume += 1;
+        } else if (conflicts.has(item.targetFullSlug)) {
+            adopt += 1;
+        } else {
+            create += 1;
+        }
+    }
+
+    const referenceCounts = countStoryReferenceStatuses(
+        graph?.storyReferences ?? [],
+    );
+
+    return {
+        sourceSpaceId,
+        targetSpaceId,
+        sameSpace: sourceSpaceId === targetSpaceId,
+        stories: {
+            total: plan.length,
+            folders: plan.filter((item) => item.type === "folder").length,
+            create,
+            resume,
+            adopt,
+        },
+        ledger,
+        references: {
+            scanned: graph !== undefined,
+            total: graph?.storyReferences.length ?? 0,
+            willRelink: referenceCounts.willRelink,
+            willBreak: referenceCounts.willBreak,
+            externalKept: referenceCounts.externalKept,
+        },
+        ...(withAssets && graph
+            ? {
+                  assets: {
+                      toCopy: graph.assets.filter(
+                          (asset) => asset.action === "create",
+                      ).length,
+                      mapped: graph.assets.filter(
+                          (asset) => asset.action === "match",
+                      ).length,
+                  },
+              }
+            : {}),
+    };
+};
+
+const plural = (count: number, singular: string, pluralForm: string) =>
+    count === 1 ? singular : pluralForm;
+
+/**
+ * Renders the PLAN block printed before the confirmation gate. Every line is
+ * a fact the run already knows; nothing here is a promise about the future
+ * beyond what the classifier and the target check established.
+ */
+export const formatCopyPlanGate = (summary: CopyPlanGateSummary): string[] => {
+    const { stories, ledger, references, assets } = summary;
+    const storyParts = [
+        `${stories.create} create`,
+        `${stories.adopt} adopt existing`,
+        `${stories.resume} resume from ledger`,
+    ];
+    const lines = [
+        "PLAN",
+        `  ${stories.total} ${plural(stories.total, "item", "items")} (${stories.folders} ${plural(stories.folders, "folder", "folders")}) -> space ${summary.targetSpaceId} (${storyParts.join(", ")})`,
+    ];
+
+    if (stories.adopt > 0) {
+        lines.push(
+            `    ${stories.adopt} existing target ${plural(stories.adopt, "path", "paths")} will be adopted and UPDATED in place.`,
+        );
+    }
+
+    if (ledger.ignored) {
+        lines.push(
+            `  ledger: ${ledger.entries} ${plural(ledger.entries, "entry", "entries")} at ${ledger.path} IGNORED (--fresh; starting empty)`,
+        );
+    } else if (ledger.entries > 0) {
+        lines.push(
+            `  ledger: ${ledger.entries} ${plural(ledger.entries, "entry", "entries")} loaded from ${ledger.path} (resuming; use --fresh to ignore)`,
+        );
+    } else {
+        lines.push(`  ledger: none at ${ledger.path} (starting empty)`);
+    }
+
+    if (!references.scanned) {
+        lines.push("  references: not scanned");
+    } else {
+        const referenceParts = [`${references.willRelink} will relink`];
+
+        if (summary.sameSpace) {
+            referenceParts.push(
+                `${references.externalKept} outside the selection kept (same space)`,
+            );
+        }
+
+        referenceParts.push(
+            references.willBreak > 0
+                ? `${references.willBreak} leave your selection and WILL BREAK`
+                : "0 will break",
+        );
+        lines.push(`  references: ${referenceParts.join(", ")}`);
+    }
+
+    if (assets) {
+        lines.push(
+            `  assets: ${assets.toCopy} will copy, ${assets.mapped} already mapped`,
+        );
+    } else {
+        lines.push("  assets: not copied (pass --with-assets)");
+    }
+
+    return lines;
+};

--- a/src/api/copy/plan-gate.ts
+++ b/src/api/copy/plan-gate.ts
@@ -1,6 +1,11 @@
-import type { CopyGraph, CopyMaps } from "./types.js";
+import type { CopyGraph } from "./types.js";
 
-import { countStoryReferenceStatuses } from "./reference-classifier.js";
+import {
+    countStoryReferenceStatuses,
+    describeBrokenStoryReferenceTarget,
+    groupBrokenStoryReferences,
+    type CopyBrokenStoryReferenceGroup,
+} from "./reference-classifier.js";
 
 /**
  * Everything a `copy stories` apply run knows before its first write, in one
@@ -10,9 +15,16 @@ import { countStoryReferenceStatuses } from "./reference-classifier.js";
  */
 export type CopyPlanGatePlanItem = {
     type: "folder" | "story";
-    sourceId?: number;
     sourceFullSlug: string;
     targetFullSlug: string;
+    /**
+     * Target story id the ledger maps this source story to, if any. A mapping
+     * only counts as a resume when the mapped story is the one actually living
+     * at `targetFullSlug` — see `existingTargetStoryId`.
+     */
+    ledgerTargetStoryId?: number;
+    /** Id of the story that already occupies `targetFullSlug` in the target. */
+    existingTargetStoryId?: number;
 };
 
 export type CopyPlanGateLedger = {
@@ -31,15 +43,21 @@ export type CopyPlanGateSummary = {
     stories: {
         total: number;
         folders: number;
-        /** No ledger mapping and no existing target path: a new shell. */
+        /** No usable ledger mapping and no existing target path: a new shell. */
         create: number;
-        /** Ledger already maps the source story: the mapped target is reused. */
+        /** The ledger maps the source story to the story at the target path. */
         resume: number;
         /**
-         * No ledger mapping but the target path already exists: the run adopts
-         * it (`matched_by_target_key`) and UPDATES it in place.
+         * No usable ledger mapping but the target path already exists: the run
+         * adopts it (`matched_by_target_key`) and UPDATES it in place.
          */
         adopt: number;
+        /**
+         * Ledger mappings that no longer resolve in the target space (the
+         * mapped story was deleted, moved or replaced). They are counted as
+         * create/adopt above, exactly as the run will treat them.
+         */
+        staleLedger: number;
     };
     ledger: CopyPlanGateLedger;
     references: {
@@ -48,6 +66,8 @@ export type CopyPlanGateSummary = {
         willRelink: number;
         willBreak: number;
         externalKept: number;
+        /** The will-break references grouped by the story that holds them. */
+        breaking: CopyBrokenStoryReferenceGroup[];
     };
     assets?: {
         toCopy: number;
@@ -55,12 +75,13 @@ export type CopyPlanGateSummary = {
     };
 };
 
+/** How many holding stories the PLAN block names before it summarises the rest. */
+const MAX_LISTED_BREAK_GROUPS = 20;
+
 export const buildCopyPlanGateSummary = ({
     sourceSpaceId,
     targetSpaceId,
     plan,
-    conflictTargetFullSlugs,
-    copyMaps,
     ledger,
     graph,
     withAssets,
@@ -68,24 +89,28 @@ export const buildCopyPlanGateSummary = ({
     sourceSpaceId: string;
     targetSpaceId: string;
     plan: CopyPlanGatePlanItem[];
-    conflictTargetFullSlugs: Iterable<string>;
-    copyMaps: CopyMaps;
     ledger: CopyPlanGateLedger;
     graph?: CopyGraph;
     withAssets: boolean;
 }): CopyPlanGateSummary => {
-    const conflicts = new Set(conflictTargetFullSlugs);
     let create = 0;
     let resume = 0;
     let adopt = 0;
+    let staleLedger = 0;
 
     for (const item of plan) {
-        if (
-            item.sourceId !== undefined &&
-            copyMaps.storyIds.has(item.sourceId)
-        ) {
-            resume += 1;
-        } else if (conflicts.has(item.targetFullSlug)) {
+        if (item.ledgerTargetStoryId !== undefined) {
+            if (item.ledgerTargetStoryId === item.existingTargetStoryId) {
+                resume += 1;
+                continue;
+            }
+
+            // The mapping is on disk but the target no longer backs it, so the
+            // run will discard it and fall through to adoption or creation.
+            staleLedger += 1;
+        }
+
+        if (item.existingTargetStoryId !== undefined) {
             adopt += 1;
         } else {
             create += 1;
@@ -106,6 +131,7 @@ export const buildCopyPlanGateSummary = ({
             create,
             resume,
             adopt,
+            staleLedger,
         },
         ledger,
         references: {
@@ -114,6 +140,7 @@ export const buildCopyPlanGateSummary = ({
             willRelink: referenceCounts.willRelink,
             willBreak: referenceCounts.willBreak,
             externalKept: referenceCounts.externalKept,
+            breaking: groupBrokenStoryReferences(graph?.storyReferences ?? []),
         },
         ...(withAssets && graph
             ? {
@@ -156,6 +183,12 @@ export const formatCopyPlanGate = (summary: CopyPlanGateSummary): string[] => {
         );
     }
 
+    if (stories.staleLedger > 0) {
+        lines.push(
+            `    ${stories.staleLedger} ledger ${plural(stories.staleLedger, "mapping", "mappings")} no longer ${plural(stories.staleLedger, "resolves", "resolve")} in space ${summary.targetSpaceId} and will be discarded.`,
+        );
+    }
+
     if (ledger.ignored) {
         lines.push(
             `  ledger: ${ledger.entries} ${plural(ledger.entries, "entry", "entries")} at ${ledger.path} IGNORED (--fresh; starting empty)`,
@@ -185,6 +218,7 @@ export const formatCopyPlanGate = (summary: CopyPlanGateSummary): string[] => {
                 : "0 will break",
         );
         lines.push(`  references: ${referenceParts.join(", ")}`);
+        lines.push(...formatBreakingReferences(references.breaking));
     }
 
     if (assets) {
@@ -193,6 +227,41 @@ export const formatCopyPlanGate = (summary: CopyPlanGateSummary): string[] => {
         );
     } else {
         lines.push("  assets: not copied (pass --with-assets)");
+    }
+
+    return lines;
+};
+
+/**
+ * The same grouped detail the dry-run prints: a count alone does not tell the
+ * operator which stories are about to lose which fields, and the gate is the
+ * last moment they can act on it.
+ */
+const formatBreakingReferences = (
+    groups: CopyBrokenStoryReferenceGroup[],
+): string[] => {
+    if (groups.length === 0) {
+        return [];
+    }
+
+    const lines = ["    WILL BREAK, by story:"];
+
+    for (const group of groups.slice(0, MAX_LISTED_BREAK_GROUPS)) {
+        lines.push(`      ${group.sourceStoryFullSlug}`);
+
+        for (const reference of group.references) {
+            lines.push(
+                `        ${reference.path} -> ${describeBrokenStoryReferenceTarget(reference)}`,
+            );
+        }
+    }
+
+    const hidden = groups.length - MAX_LISTED_BREAK_GROUPS;
+
+    if (hidden > 0) {
+        lines.push(
+            `      ...and ${hidden} more ${plural(hidden, "story", "stories")} with breaking references; run with --dryRun for the full list.`,
+        );
     }
 
     return lines;

--- a/src/api/copy/plan-gate.ts
+++ b/src/api/copy/plan-gate.ts
@@ -211,31 +211,47 @@ export const formatCopyPlanGate = (summary: CopyPlanGateSummary): string[] => {
     return lines;
 };
 
-/** The one line stating where the ledger came from and whether it is used. */
+/**
+ * The one line stating where the ledger came from and whether it is used.
+ * `resumeNote` is what the loaded-ledger line says in brackets; a command
+ * without `--fresh` must not advertise it, so it passes its own note.
+ */
 export const formatCopyPlanGateLedger = (
     ledger: CopyPlanGateLedger,
+    {
+        resumeNote = "resuming; use --fresh to ignore",
+    }: {
+        resumeNote?: string;
+    } = {},
 ): string => {
     if (ledger.ignored) {
         return `  ledger: ${ledger.entries} ${plural(ledger.entries, "entry", "entries")} at ${ledger.path} IGNORED (--fresh; starting empty)`;
     }
 
     if (ledger.entries > 0) {
-        return `  ledger: ${ledger.entries} ${plural(ledger.entries, "entry", "entries")} loaded from ${ledger.path} (resuming; use --fresh to ignore)`;
+        return `  ledger: ${ledger.entries} ${plural(ledger.entries, "entry", "entries")} loaded from ${ledger.path} (${resumeNote})`;
     }
 
     return `  ledger: none at ${ledger.path} (starting empty)`;
 };
 
-/** The reference counts and, when anything dangles, the grouped detail. */
+/**
+ * The reference counts and, when anything dangles, the grouped detail. The
+ * `label` names what the counts were measured against: `copy stories` scans
+ * the content it is about to copy, so plain `references` is the whole truth,
+ * while a command that rewrites something else must say so.
+ */
 export const formatCopyPlanGateReferences = ({
     references,
     sameSpace,
+    label = "references",
 }: {
     references: CopyPlanGateReferences;
     sameSpace: boolean;
+    label?: string;
 }): string[] => {
     if (!references.scanned) {
-        return ["  references: not scanned"];
+        return [`  ${label}: not scanned`];
     }
 
     const parts = [`${references.willRelink} will relink`];
@@ -253,7 +269,7 @@ export const formatCopyPlanGateReferences = ({
     );
 
     return [
-        `  references: ${parts.join(", ")}`,
+        `  ${label}: ${parts.join(", ")}`,
         ...formatBreakingReferences(references.breaking),
     ];
 };

--- a/src/api/copy/reference-classifier.ts
+++ b/src/api/copy/reference-classifier.ts
@@ -1,0 +1,213 @@
+import type {
+    CopyGraphStoryNode,
+    CopyGraphStoryReference,
+    CopyMaps,
+    CopyStoryReferenceStatus,
+} from "./types.js";
+
+/**
+ * The set of source stories a copy run is about to write. Built from the copy
+ * plan, so a reference pointing into it is guaranteed to have a mapping by the
+ * time phase 2 rewrites content.
+ */
+export type CopyReferenceSelection = {
+    storyIds: Set<number>;
+    storyUuids: Set<string>;
+};
+
+export type CopyStoryReferenceStatusCounts = {
+    willRelink: number;
+    willBreak: number;
+    externalKept: number;
+    unresolved: number;
+    unsupported: number;
+    unclassified: number;
+};
+
+export type CopyBrokenStoryReferenceGroup = {
+    sourceStoryFullSlug: string;
+    references: CopyGraphStoryReference[];
+};
+
+/**
+ * `parent_id` is resolved by the copy plan itself: phase 1 creates every shell
+ * under its planned parent, and the top of the selection lands under the
+ * destination. It cannot dangle the way a content reference can, so it is
+ * never reported as a break — even when the source parent is out of scope.
+ */
+const STRUCTURAL_REFERENCE_PATHS = new Set(["parent_id"]);
+
+export const buildCopyReferenceSelection = (
+    stories: CopyGraphStoryNode[],
+): CopyReferenceSelection => {
+    const storyIds = new Set<number>();
+    const storyUuids = new Set<string>();
+
+    for (const story of stories) {
+        // Plan items whose source story could not be resolved carry sourceId 0.
+        if (Number.isFinite(story.sourceId) && story.sourceId > 0) {
+            storyIds.add(story.sourceId);
+        }
+
+        if (story.sourceUuid) {
+            storyUuids.add(story.sourceUuid);
+        }
+    }
+
+    return { storyIds, storyUuids };
+};
+
+export const createEmptyCopyReferenceSelection =
+    (): CopyReferenceSelection => ({
+        storyIds: new Set(),
+        storyUuids: new Set(),
+    });
+
+const isInSelection = (
+    reference: CopyGraphStoryReference,
+    selection: CopyReferenceSelection,
+): boolean =>
+    (reference.referencedStoryId !== undefined &&
+        selection.storyIds.has(reference.referencedStoryId)) ||
+    (reference.referencedStoryUuid !== undefined &&
+        selection.storyUuids.has(reference.referencedStoryUuid));
+
+const isInLedger = (
+    reference: CopyGraphStoryReference,
+    copyMaps: CopyMaps,
+): boolean =>
+    (reference.referencedStoryId !== undefined &&
+        copyMaps.storyIds.has(reference.referencedStoryId)) ||
+    (reference.referencedStoryUuid !== undefined &&
+        copyMaps.storyUuids.has(reference.referencedStoryUuid));
+
+export const classifyStoryReferenceStatus = ({
+    reference,
+    selection,
+    copyMaps,
+    sameSpace,
+}: {
+    reference: CopyGraphStoryReference;
+    selection: CopyReferenceSelection;
+    copyMaps: CopyMaps;
+    sameSpace: boolean;
+}): CopyStoryReferenceStatus => {
+    // The scanner already decided these; the copy plan cannot improve on them.
+    if (
+        reference.status === "unresolved" ||
+        reference.status === "unsupported"
+    ) {
+        return reference.status;
+    }
+
+    if (STRUCTURAL_REFERENCE_PATHS.has(reference.path)) {
+        return "will_relink";
+    }
+
+    if (
+        isInSelection(reference, selection) ||
+        isInLedger(reference, copyMaps)
+    ) {
+        return "will_relink";
+    }
+
+    return sameSpace ? "external_kept" : "will_break";
+};
+
+export const classifyStoryReferences = ({
+    storyReferences,
+    selection,
+    copyMaps,
+    sameSpace,
+}: {
+    storyReferences: CopyGraphStoryReference[];
+    selection: CopyReferenceSelection;
+    copyMaps: CopyMaps;
+    sameSpace: boolean;
+}): CopyGraphStoryReference[] =>
+    storyReferences.map((reference) => ({
+        ...reference,
+        status: classifyStoryReferenceStatus({
+            reference,
+            selection,
+            copyMaps,
+            sameSpace,
+        }),
+    }));
+
+export const countStoryReferenceStatuses = (
+    storyReferences: CopyGraphStoryReference[],
+): CopyStoryReferenceStatusCounts => {
+    const counts: CopyStoryReferenceStatusCounts = {
+        willRelink: 0,
+        willBreak: 0,
+        externalKept: 0,
+        unresolved: 0,
+        unsupported: 0,
+        unclassified: 0,
+    };
+
+    for (const reference of storyReferences) {
+        switch (reference.status) {
+            case "will_relink":
+                counts.willRelink += 1;
+                break;
+            case "will_break":
+                counts.willBreak += 1;
+                break;
+            case "external_kept":
+                counts.externalKept += 1;
+                break;
+            case "unresolved":
+                counts.unresolved += 1;
+                break;
+            case "unsupported":
+                counts.unsupported += 1;
+                break;
+            default:
+                counts.unclassified += 1;
+                break;
+        }
+    }
+
+    return counts;
+};
+
+/**
+ * Groups the references that will dangle by the story that holds them, so the
+ * report can name a story once and list its offending field paths under it.
+ */
+export const groupBrokenStoryReferences = (
+    storyReferences: CopyGraphStoryReference[],
+): CopyBrokenStoryReferenceGroup[] => {
+    const groups = new Map<string, CopyBrokenStoryReferenceGroup>();
+
+    for (const reference of storyReferences) {
+        if (reference.status !== "will_break") {
+            continue;
+        }
+
+        const sourceStoryFullSlug =
+            reference.sourceStoryFullSlug ??
+            (reference.sourceStoryId !== undefined
+                ? `#${reference.sourceStoryId}`
+                : "<unknown story>");
+        const group = groups.get(sourceStoryFullSlug) ?? {
+            sourceStoryFullSlug,
+            references: [],
+        };
+
+        group.references.push(reference);
+        groups.set(sourceStoryFullSlug, group);
+    }
+
+    return Array.from(groups.values());
+};
+
+export const describeBrokenStoryReferenceTarget = (
+    reference: CopyGraphStoryReference,
+): string =>
+    reference.referencedStoryUuid ??
+    (reference.referencedStoryId !== undefined
+        ? `#${reference.referencedStoryId}`
+        : "<unknown target>");

--- a/src/api/copy/reference-classifier.ts
+++ b/src/api/copy/reference-classifier.ts
@@ -37,13 +37,26 @@ export type CopyBrokenStoryReferenceGroup = {
  */
 const STRUCTURAL_REFERENCE_PATHS = new Set(["parent_id"]);
 
+/**
+ * `excludeSourceFullSlugs` names planned stories the run will NOT map. `copy
+ * stories` creates every planned story, so it excludes nothing; `copy relink`
+ * never creates, so a reference into a story missing from the target has to
+ * classify as a break rather than a promise to relink.
+ */
 export const buildCopyReferenceSelection = (
     stories: CopyGraphStoryNode[],
+    {
+        excludeSourceFullSlugs,
+    }: { excludeSourceFullSlugs?: ReadonlySet<string> } = {},
 ): CopyReferenceSelection => {
     const storyIds = new Set<number>();
     const storyUuids = new Set<string>();
 
     for (const story of stories) {
+        if (excludeSourceFullSlugs?.has(story.sourceFullSlug)) {
+            continue;
+        }
+
         // Plan items whose source story could not be resolved carry sourceId 0.
         if (Number.isFinite(story.sourceId) && story.sourceId > 0) {
             storyIds.add(story.sourceId);

--- a/src/api/copy/reference-scanner.ts
+++ b/src/api/copy/reference-scanner.ts
@@ -15,7 +15,6 @@ type StoryLike = {
     uuid?: string;
     full_slug?: string;
     parent_id?: number | null;
-    alternates?: Array<{ id?: number; parent_id?: number | null }>;
     content?: Record<string, unknown>;
 };
 
@@ -150,21 +149,9 @@ const scanStoryMetadata = (story: StoryLike, state: ScannerState) => {
         });
     }
 
-    story.alternates?.forEach((alternate, index) => {
-        if (typeof alternate.id === "number") {
-            addStoryReference(state, {
-                path: `alternates[${index}].id`,
-                referencedStoryId: alternate.id,
-            });
-        }
-
-        if (typeof alternate.parent_id === "number") {
-            addStoryReference(state, {
-                path: `alternates[${index}].parent_id`,
-                referencedStoryId: alternate.parent_id,
-            });
-        }
-    });
+    // `alternates` is read-only API metadata that the copy payload strips
+    // before writing, so it is never rewritten and never dangles. Scanning it
+    // would report references that no copy phase acts on.
 };
 
 const scanComponentNode = (

--- a/src/api/copy/reference-scanner.ts
+++ b/src/api/copy/reference-scanner.ts
@@ -141,7 +141,9 @@ export const scanStoriesReferences = ({
 };
 
 const scanStoryMetadata = (story: StoryLike, state: ScannerState) => {
-    if (typeof story.parent_id === "number") {
+    // parent_id 0 is Storyblok's "lives at the space root" sentinel, not a
+    // story id. Recording it inflated every reference count with a phantom.
+    if (typeof story.parent_id === "number" && story.parent_id !== 0) {
         addStoryReference(state, {
             path: "parent_id",
             referencedStoryId: story.parent_id,
@@ -503,9 +505,12 @@ const addStoryReference = (
         type: "story_reference",
         ...state.context,
         ...reference,
+        // The scanner sees one story at a time, so it cannot know whether the
+        // referenced story is inside the copy plan. The classifier decides
+        // that; see classifyStoryReferences in ./reference-classifier.ts.
         status:
             state.options.referencePolicy === "preserve"
-                ? "preserved_external"
+                ? "unclassified"
                 : "unresolved",
     });
 };

--- a/src/api/copy/relink.ts
+++ b/src/api/copy/relink.ts
@@ -1,0 +1,188 @@
+import type { CopyComponentSchemaRegistry, CopyMaps } from "./types.js";
+
+import {
+    formatCopyPlanGateLedger,
+    formatCopyPlanGateReferences,
+    type CopyPlanGateLedger,
+    type CopyPlanGateReferences,
+} from "./plan-gate.js";
+import { rewriteCopyReferences } from "./reference-rewriter.js";
+
+/**
+ * How a planned story was matched to a story that already exists in the target
+ * space. `missing` stories were never copied, so there is nothing to repair.
+ */
+export type CopyRelinkMatch = "ledger" | "adopted" | "missing";
+
+export type CopyRelinkPlanItem = {
+    type: "folder" | "story";
+    sourceFullSlug: string;
+    targetFullSlug: string;
+    match: CopyRelinkMatch;
+    /**
+     * References this run would rewrite in the story's *target* content, as
+     * counted against the completed mapping. Zero for folders, for missing
+     * stories and for stories whose references already resolve.
+     */
+    rewrittenReferences: number;
+    /** Whether the rewrite actually changes the stored content. */
+    changed: boolean;
+};
+
+export type CopyRelinkPlanSummary = {
+    sourceSpaceId: string;
+    targetSpaceId: string;
+    sameSpace: boolean;
+    stories: {
+        total: number;
+        folders: number;
+        /** Matched through an existing, still valid ledger mapping. */
+        fromLedger: number;
+        /** Matched by target path; the run records the mapping before rewriting. */
+        adopted: number;
+        /** Planned but absent from the target: nothing to relink. */
+        missing: number;
+        /** Stories whose target content this run will update. */
+        toUpdate: number;
+        /**
+         * Matched stories whose references already resolve; left untouched.
+         * Folders are counted in neither: they hold no content.
+         */
+        unchanged: number;
+    };
+    /** References the run will rewrite across every story it updates. */
+    rewrittenReferences: number;
+    ledger: CopyPlanGateLedger;
+    references: CopyPlanGateReferences;
+};
+
+export const buildCopyRelinkPlanSummary = ({
+    sourceSpaceId,
+    targetSpaceId,
+    plan,
+    ledger,
+    references,
+}: {
+    sourceSpaceId: string;
+    targetSpaceId: string;
+    plan: CopyRelinkPlanItem[];
+    ledger: CopyPlanGateLedger;
+    references: CopyPlanGateReferences;
+}): CopyRelinkPlanSummary => {
+    // Folders carry no content, so they are neither updated nor "already
+    // correct" — only stories are candidates for a rewrite.
+    const rewritable = plan.filter(
+        (item) => item.match !== "missing" && item.type === "story",
+    );
+
+    return {
+        sourceSpaceId,
+        targetSpaceId,
+        sameSpace: sourceSpaceId === targetSpaceId,
+        stories: {
+            total: plan.length,
+            folders: plan.filter((item) => item.type === "folder").length,
+            fromLedger: plan.filter((item) => item.match === "ledger").length,
+            adopted: plan.filter((item) => item.match === "adopted").length,
+            missing: plan.filter((item) => item.match === "missing").length,
+            toUpdate: rewritable.filter((item) => item.changed).length,
+            unchanged: rewritable.filter((item) => !item.changed).length,
+        },
+        rewrittenReferences: plan.reduce(
+            (total, item) =>
+                total + (item.changed ? item.rewrittenReferences : 0),
+            0,
+        ),
+        ledger,
+        references,
+    };
+};
+
+const plural = (count: number, singular: string, pluralForm: string) =>
+    count === 1 ? singular : pluralForm;
+
+/**
+ * The PLAN block `copy relink` prints before its first write. Unlike the copy
+ * gate's counts, the rewrite figures here are not estimates: the target content
+ * has already been read and rewritten in memory, so the block states exactly
+ * what the run is about to store.
+ */
+export const formatCopyRelinkPlan = (
+    summary: CopyRelinkPlanSummary,
+): string[] => {
+    const { stories, ledger, references } = summary;
+    const matchParts = [
+        `${stories.fromLedger} mapped by ledger`,
+        `${stories.adopted} adopted by target path`,
+        `${stories.missing} missing from target`,
+    ];
+    const lines = [
+        "PLAN",
+        `  ${stories.total} planned ${plural(stories.total, "item", "items")} (${stories.folders} ${plural(stories.folders, "folder", "folders")}) in space ${summary.targetSpaceId} (${matchParts.join(", ")})`,
+    ];
+
+    if (stories.adopted > 0) {
+        lines.push(
+            `    ${stories.adopted} target ${plural(stories.adopted, "story", "stories")} will be added to the ledger as matched_by_target_key.`,
+        );
+    }
+
+    if (stories.missing > 0) {
+        lines.push(
+            `    ${stories.missing} planned ${plural(stories.missing, "story is", "stories are")} not in the target and cannot be relinked; copy ${plural(stories.missing, "it", "them")} first.`,
+        );
+    }
+
+    lines.push(formatCopyPlanGateLedger(ledger));
+    lines.push(
+        ...formatCopyPlanGateReferences({
+            references,
+            sameSpace: summary.sameSpace,
+        }),
+    );
+    lines.push(
+        `  rewrite: ${summary.rewrittenReferences} ${plural(summary.rewrittenReferences, "reference", "references")} in ${stories.toUpdate} ${plural(stories.toUpdate, "story", "stories")}; ${stories.unchanged} already correct and left untouched`,
+    );
+    lines.push(
+        "  content: only reference values change; nothing is copied from the source",
+    );
+
+    return lines;
+};
+
+export type CopyRelinkStoryRewrite = {
+    content: unknown;
+    rewrittenReferences: number;
+    changed: boolean;
+};
+
+/**
+ * The relink rewrite of one already-copied target story: the target's own
+ * content with its reference values remapped.
+ *
+ * Whether to write is decided by comparing values, not by counting rewrite
+ * records — a reference that maps to itself records a rewrite without changing
+ * a byte, and a story that is already correct must be left alone.
+ */
+export const planCopyRelinkStoryRewrite = ({
+    content,
+    maps,
+    schemas,
+}: {
+    content: unknown;
+    maps: CopyMaps;
+    schemas?: CopyComponentSchemaRegistry;
+}): CopyRelinkStoryRewrite => {
+    const original = content ?? {};
+    const rewritten = rewriteCopyReferences({
+        value: original,
+        maps,
+        schemas,
+    });
+
+    return {
+        content: rewritten.value,
+        rewrittenReferences: rewritten.records.length,
+        changed: JSON.stringify(rewritten.value) !== JSON.stringify(original),
+    };
+};

--- a/src/api/copy/relink.ts
+++ b/src/api/copy/relink.ts
@@ -1,5 +1,10 @@
-import type { CopyComponentSchemaRegistry, CopyMaps } from "./types.js";
+import type {
+    CopyComponentSchemaRegistry,
+    CopyManifestEntry,
+    CopyMaps,
+} from "./types.js";
 
+import { createEmptyCopyMaps } from "./manifest.js";
 import {
     formatCopyPlanGateLedger,
     formatCopyPlanGateReferences,
@@ -54,6 +59,144 @@ export type CopyRelinkPlanSummary = {
     rewrittenReferences: number;
     ledger: CopyPlanGateLedger;
     references: CopyPlanGateReferences;
+};
+
+/**
+ * One source story mapped to the story that actually backs it in the target,
+ * as proven by this run at the moment it built its maps.
+ */
+export type CopyRelinkStoryMapping = {
+    sourceId: number;
+    sourceUuid: string;
+    targetId: number;
+    targetUuid: string;
+    sourceFullSlug: string;
+    targetFullSlug: string;
+};
+
+/**
+ * The maps `copy relink` rewrites through. Story mappings come ONLY from
+ * matches this run validated against the target space — a ledger line whose
+ * target story is gone would otherwise rewrite a live reference to a deleted
+ * uuid, which is worse than the break the command was asked to repair. Asset
+ * mappings carry over untouched: they record copied files, and no story match
+ * can invalidate them.
+ */
+export const buildCopyRelinkMaps = ({
+    ledgerMaps,
+    storyMappings,
+}: {
+    ledgerMaps: CopyMaps;
+    storyMappings: CopyRelinkStoryMapping[];
+}): CopyMaps => {
+    const maps = createEmptyCopyMaps();
+
+    ledgerMaps.assetIds.forEach((value, key) => maps.assetIds.set(key, value));
+    ledgerMaps.assetFilenames.forEach((value, key) =>
+        maps.assetFilenames.set(key, value),
+    );
+    ledgerMaps.assetFolderIds.forEach((value, key) =>
+        maps.assetFolderIds.set(key, value),
+    );
+
+    for (const mapping of storyMappings) {
+        maps.storyIds.set(mapping.sourceId, mapping.targetId);
+        maps.storyUuids.set(mapping.sourceUuid, mapping.targetUuid);
+    }
+
+    return maps;
+};
+
+/**
+ * The maps the PLAN's reference counts are read against. Unlike the rewrite
+ * maps, these keep the ledger's own out-of-selection mappings: a reference the
+ * ledger already covers is not a break just because this run never had to
+ * touch it. What they must not keep is any mapping this run PROVED stale —
+ * otherwise the plan promises a relink the rewrite will refuse.
+ */
+export const buildCopyRelinkClassificationMaps = ({
+    ledgerMaps,
+    storyMappings,
+    staleStoryKeys,
+}: {
+    ledgerMaps: CopyMaps;
+    storyMappings: CopyRelinkStoryMapping[];
+    staleStoryKeys: Array<{ sourceId: number; sourceUuid: string }>;
+}): CopyMaps => {
+    const maps: CopyMaps = {
+        storyIds: new Map(ledgerMaps.storyIds),
+        storyUuids: new Map(ledgerMaps.storyUuids),
+        assetIds: new Map(ledgerMaps.assetIds),
+        assetFilenames: new Map(ledgerMaps.assetFilenames),
+        assetFolderIds: new Map(ledgerMaps.assetFolderIds),
+    };
+
+    for (const key of staleStoryKeys) {
+        maps.storyIds.delete(key.sourceId);
+        maps.storyUuids.delete(key.sourceUuid);
+    }
+
+    for (const mapping of storyMappings) {
+        maps.storyIds.set(mapping.sourceId, mapping.targetId);
+        maps.storyUuids.set(mapping.sourceUuid, mapping.targetUuid);
+    }
+
+    return maps;
+};
+
+const mentionsStoryReference = (
+    serializedContent: string,
+    { sourceId, sourceUuid }: { sourceId: number; sourceUuid: string },
+): boolean =>
+    (sourceUuid.length > 0 && serializedContent.includes(sourceUuid)) ||
+    (Number.isFinite(sourceId) &&
+        new RegExp(`(^|[^0-9])${sourceId}([^0-9]|$)`).test(serializedContent));
+
+/**
+ * Ledger mappings for stories OUTSIDE the relink selection that the target
+ * content actually mentions — the `shared/header` a relink of `pages` alone
+ * still has to repair. These are candidates, not conclusions: the caller
+ * validates each one against the target space before it may join the rewrite
+ * maps.
+ *
+ * The mention test is a substring scan of the target content and deliberately
+ * generous: a false positive costs one lookup, a miss would silently leave a
+ * reference unrepaired.
+ */
+export const selectRelinkLedgerStoryMappings = ({
+    entries,
+    plannedSourceIds,
+    targetContents,
+}: {
+    entries: CopyManifestEntry[];
+    plannedSourceIds: Set<number>;
+    targetContents: unknown[];
+}): CopyRelinkStoryMapping[] => {
+    const serializedContent = targetContents
+        .map((content) => JSON.stringify(content ?? null))
+        .join("\n");
+    const mappings = new Map<number, CopyRelinkStoryMapping>();
+
+    for (const entry of entries) {
+        if (entry.type !== "story" || plannedSourceIds.has(entry.source_id)) {
+            continue;
+        }
+
+        const mapping: CopyRelinkStoryMapping = {
+            sourceId: Number(entry.source_id),
+            sourceUuid: String(entry.source_uuid ?? ""),
+            targetId: Number(entry.target_id),
+            targetUuid: String(entry.target_uuid ?? ""),
+            sourceFullSlug: String(entry.source_full_slug ?? ""),
+            targetFullSlug: String(entry.target_full_slug ?? ""),
+        };
+
+        if (mentionsStoryReference(serializedContent, mapping)) {
+            mappings.set(mapping.sourceId, mapping);
+        }
+    }
+
+    return Array.from(mappings.values());
 };
 
 export const buildCopyRelinkPlanSummary = ({
@@ -133,13 +276,36 @@ export const formatCopyRelinkPlan = (
         );
     }
 
-    lines.push(formatCopyPlanGateLedger(ledger));
     lines.push(
-        ...formatCopyPlanGateReferences({
-            references,
-            sameSpace: summary.sameSpace,
+        // `copy relink` has no `--fresh`: the ledger is its input, and target
+        // path adoption already fills whatever the ledger is missing.
+        formatCopyPlanGateLedger(ledger, {
+            resumeNote: "completing the mapping from the target space",
         }),
     );
+
+    // The scan reads the SOURCE stories this selection covers, while the
+    // rewrite below is measured in the TARGET content relink actually writes.
+    // The two answer different questions and their counts legitimately differ,
+    // so the line says which one it is instead of implying the other.
+    const referenceLines = formatCopyPlanGateReferences({
+        references,
+        sameSpace: summary.sameSpace,
+        label: "source references",
+    });
+
+    lines.push(
+        ...referenceLines.slice(0, 1),
+        "    Counted in the source content this selection covers, against the mapping above; the rewrite line below is what changes in the target.",
+        ...referenceLines.slice(1),
+    );
+
+    if (stories.missing > 0 && references.willBreak > 0) {
+        lines.push(
+            `    References into ${plural(stories.missing, "the story", "stories")} missing from the target cannot be repaired here; copy ${plural(stories.missing, "it", "them")} first, then relink again.`,
+        );
+    }
+
     lines.push(
         `  rewrite: ${summary.rewrittenReferences} ${plural(summary.rewrittenReferences, "reference", "references")} in ${stories.toUpdate} ${plural(stories.toUpdate, "story", "stories")}; ${stories.unchanged} already correct and left untouched`,
     );

--- a/src/api/copy/types.ts
+++ b/src/api/copy/types.ts
@@ -121,6 +121,28 @@ export type CopyGraphAssetFolderNode = {
     action: CopyGraphAction;
 };
 
+/**
+ * Scope-aware lifecycle of a scanned story reference.
+ *
+ * - `unclassified` — emitted by the scanner, which sees a single story and
+ *   therefore cannot know the copy plan. Replaced by the classifier.
+ * - `will_relink` — the referenced story is inside the selection (its mapping
+ *   will exist by phase 2) or is already in the loaded ledger.
+ * - `will_break` — the referenced story is outside the selection and not in
+ *   the ledger; in a cross-space copy this reference dangles.
+ * - `external_kept` — same-space copy, where pointing at the original story
+ *   remains correct.
+ * - `unresolved` — reference policy `fail`: the reference cannot be handled.
+ * - `unsupported` — the reference shape is not rewritable.
+ */
+export type CopyStoryReferenceStatus =
+    | "unclassified"
+    | "will_relink"
+    | "will_break"
+    | "external_kept"
+    | "unresolved"
+    | "unsupported";
+
 export type CopyGraphStoryReference = {
     type: "story_reference";
     sourceStoryId?: number;
@@ -129,7 +151,7 @@ export type CopyGraphStoryReference = {
     referencedStoryId?: number;
     referencedStoryUuid?: string;
     path: string;
-    status: "mapped" | "preserved_external" | "unresolved" | "unsupported";
+    status: CopyStoryReferenceStatus;
 };
 
 export type CopyGraphAssetReference = {

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -248,7 +248,7 @@ export const copyDescription = `
         --referenced-by-stories
                        Select assets referenced by a story/folder scope. Requires --source. [assets only]
         --dry-run       Preview story paths, manifest-mapped references, and likely target conflicts without writing to Storyblok.
-        --yes           Skip the 'Continue? [y/N]' plan gate that copy stories shows before its first write. Required in non-interactive runs (CI). [stories only]
+        --yes           Skip the confirmation gate that copy stories shows after its PLAN block, before its first write. Required in non-interactive runs (CI). [stories only]
         --fresh         Ignore the existing copy ledger for this run; existing manifest files are moved aside with a timestamp suffix, never deleted. [stories only]
         --outputPath    Optional JSON file path for a dry-run copy plan artifact. Only writes locally when passed.
 
@@ -272,7 +272,7 @@ export const copyDescription = `
         mode 'subtree' copies a folder and all descendants. This is the default for folders.
         mode 'children' copies a folder's descendants without the folder root.
         mode 'self' copies only the source story or folder shell.
-        copy stories prints a PLAN block (create/adopt/resume counts, ledger, will-relink/will-break references, assets) and asks 'Continue? [y/N]' before any write; pass --yes to skip the question. Without a terminal and without --yes it refuses to write.
+        copy stories prints a PLAN block (create/adopt/resume counts, ledger, will-relink/will-break references, assets) and asks for confirmation before any write; pass --yes to skip the question. Without a terminal and without --yes it refuses to write.
         copy stories creates or matches target story shells, then fills them with rewritten source content.
         copy stories matches existing targets by manifest first, then target full_slug when safe, so reruns can reuse mapped target stories.
         copy stories rewrites mapped asset and story references after story manifests exist.

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -249,7 +249,7 @@ export const copyDescription = `
                        Select assets referenced by a story/folder scope. Requires --source. [assets only]
         --dry-run       Preview story paths, manifest-mapped references, and likely target conflicts without writing to Storyblok.
         --yes           Skip the confirmation gate that copy stories shows after its PLAN block, before its first write. Required in non-interactive runs (CI). [stories only]
-        --fresh         Ignore the existing copy ledger for this run; existing manifest files are moved aside with a timestamp suffix, never deleted. [stories only]
+        --fresh         Ignore the existing copy ledger for this run; every manifest file of this space pair, the asset and asset-folder ledgers included, is moved aside with a timestamp suffix, never deleted. A later --with-assets run therefore starts without the archived asset mappings too. [stories only]
         --outputPath    Optional JSON file path for a dry-run copy plan artifact. Only writes locally when passed.
 
     LEGACY FLAGS

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -218,6 +218,8 @@ export const copyDescription = `
         $ sb-mig copy stories --from [spaceId] --to [spaceId] --source [folder_full_slug]
         $ sb-mig copy stories --from [spaceId] --to [spaceId] --source [folder_full_slug]/* --destination [target_folder_full_slug]
         $ sb-mig copy stories --from [spaceId] --to [spaceId] --source [folder_full_slug] --mode self --destination /
+        $ sb-mig copy relink --from [spaceId] --to [spaceId] --source [folder_full_slug] --destination [target_folder_full_slug]
+        $ sb-mig copy relink --from [spaceId] --to [spaceId] --source [folder_full_slug] --dry-run
         $ sb-mig copy assets --from [spaceId] --to [spaceId] --all
         $ sb-mig copy assets --from [spaceId] --to [spaceId] --asset [asset_id_or_filename]
         $ sb-mig copy assets --from [spaceId] --to [spaceId] --assetFolder [folder_id_or_path]
@@ -229,6 +231,7 @@ export const copyDescription = `
 
     COMMANDS
         stories         Copy one story, one folder subtree, a folder's children, or one folder shell.
+        relink          Repair references in stories that were already copied, without copying content again.
         assets          Copy or plan all assets and asset folders with durable manifests.
 
     FLAGS
@@ -248,7 +251,7 @@ export const copyDescription = `
         --referenced-by-stories
                        Select assets referenced by a story/folder scope. Requires --source. [assets only]
         --dry-run       Preview story paths, manifest-mapped references, and likely target conflicts without writing to Storyblok.
-        --yes           Skip the confirmation gate that copy stories shows after its PLAN block, before its first write. Required in non-interactive runs (CI). [stories only]
+        --yes           Skip the confirmation gate that copy stories and copy relink show after their PLAN block, before their first write. Required in non-interactive runs (CI). [stories and relink only]
         --fresh         Ignore the existing copy ledger for this run; every manifest file of this space pair, the asset and asset-folder ledgers included, is moved aside with a timestamp suffix, never deleted. A later --with-assets run therefore starts without the archived asset mappings too. [stories only]
         --outputPath    Optional JSON file path for a dry-run copy plan artifact. Only writes locally when passed.
 
@@ -259,6 +262,8 @@ export const copyDescription = `
         --where         Alias for --destination.
 
     SIDE EFFECTS
+        copy relink updates the content of already-copied target stories unless --dry-run is passed. Only reference values change.
+        copy relink appends matched_by_target_key entries to the story manifest for target stories it matches by path.
         copy stories writes copied stories into the target Storyblok space unless --dry-run is passed.
         copy stories writes story ID/UUID manifests under .sb-mig/copy/<source>/<target>/ during apply.
         copy stories --with-assets writes referenced asset folders/assets before story writes unless --dry-run is passed.
@@ -273,6 +278,11 @@ export const copyDescription = `
         mode 'children' copies a folder's descendants without the folder root.
         mode 'self' copies only the source story or folder shell.
         copy stories prints a PLAN block (create/adopt/resume counts, ledger, will-relink/will-break references, assets) and asks for confirmation before any write; pass --yes to skip the question. Without a terminal and without --yes it refuses to write.
+        copy relink repairs stories that were copied before the stories they reference, which leaves source-space IDs and UUIDs in target content forever; copying the referenced stories later does not fix the content that was already written.
+        copy relink takes the same --source, --destination and --mode as the copy stories run it repairs, so the planned target paths line up.
+        copy relink builds the mapping from the ledger plus target paths, then rewrites each target story's own content. It never creates stories and never copies content from the source.
+        copy relink leaves a story untouched when its references already resolve, and updates the draft only, so published stories need publishing afterwards.
+        copy relink prints the same PLAN block and confirmation gate as copy stories, with the exact number of references it is about to rewrite.
         copy stories creates or matches target story shells, then fills them with rewritten source content.
         copy stories matches existing targets by manifest first, then target full_slug when safe, so reruns can reuse mapped target stories.
         copy stories rewrites mapped asset and story references after story manifests exist.

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -248,6 +248,8 @@ export const copyDescription = `
         --referenced-by-stories
                        Select assets referenced by a story/folder scope. Requires --source. [assets only]
         --dry-run       Preview story paths, manifest-mapped references, and likely target conflicts without writing to Storyblok.
+        --yes           Skip the 'Continue? [y/N]' plan gate that copy stories shows before its first write. Required in non-interactive runs (CI). [stories only]
+        --fresh         Ignore the existing copy ledger for this run; existing manifest files are moved aside with a timestamp suffix, never deleted. [stories only]
         --outputPath    Optional JSON file path for a dry-run copy plan artifact. Only writes locally when passed.
 
     LEGACY FLAGS
@@ -270,6 +272,7 @@ export const copyDescription = `
         mode 'subtree' copies a folder and all descendants. This is the default for folders.
         mode 'children' copies a folder's descendants without the folder root.
         mode 'self' copies only the source story or folder shell.
+        copy stories prints a PLAN block (create/adopt/resume counts, ledger, will-relink/will-break references, assets) and asks 'Continue? [y/N]' before any write; pass --yes to skip the question. Without a terminal and without --yes it refuses to write.
         copy stories creates or matches target story shells, then fills them with rewritten source content.
         copy stories matches existing targets by manifest first, then target full_slug when safe, so reruns can reuse mapped target stories.
         copy stories rewrites mapped asset and story references after story manifests exist.

--- a/src/cli/commands/copy.ts
+++ b/src/cli/commands/copy.ts
@@ -2243,10 +2243,17 @@ const annotateReferencesWithManifestMaps = ({
     graph,
     copyMaps,
     withAssets,
+    classifyStories,
 }: {
     graph: CopyGraph;
     copyMaps: CopyMaps;
     withAssets: boolean;
+    /**
+     * Only a story-copy run rewrites story references, so only it can promise
+     * `will_relink` or warn `will_break`. Asset-only runs leave the scanner's
+     * neutral `unclassified` status in place.
+     */
+    classifyStories: boolean;
 }) => {
     for (const reference of graph.assetReferences) {
         if (hasMappedAssetReference({ ...reference, copyMaps })) {
@@ -2257,6 +2264,10 @@ const annotateReferencesWithManifestMaps = ({
         if (!withAssets && reference.status === "planned") {
             reference.status = "unresolved";
         }
+    }
+
+    if (!classifyStories) {
+        return;
     }
 
     // Story references are classified against the copy plan as well as the
@@ -2328,6 +2339,27 @@ const annotateAssetsWithManifestMaps = ({
     }
 };
 
+/**
+ * Restricts the scan input to the stories the plan will actually write. The
+ * selection fetch can return more than the plan (children mode fetches the
+ * root folder but does not copy it); scanning those would attribute
+ * references to a run that never touches them.
+ */
+const selectPlannedSourceStories = (
+    sourceStories: any[],
+    plan: CopyPlanItem[],
+): any[] => {
+    const plannedFullSlugs = new Set(plan.map((item) => item.sourceFullSlug));
+
+    return sourceStories
+        .map((item) => item?.story)
+        .filter(
+            (story) =>
+                Boolean(story) &&
+                plannedFullSlugs.has(String(story.full_slug ?? "")),
+        );
+};
+
 const buildStoryReferenceDryRunGraph = ({
     sourceSpace,
     targetSpace,
@@ -2360,7 +2392,7 @@ const buildStoryReferenceDryRunGraph = ({
             .map((story) => [String(story.full_slug ?? ""), story] as const),
     );
     const scanResult = scanStoriesReferences({
-        stories: sourceStories.map((item) => item?.story).filter(Boolean),
+        stories: selectPlannedSourceStories(sourceStories, plan),
         schemas,
         options: {
             referencePolicy: "preserve",
@@ -2401,6 +2433,7 @@ const buildStoryReferenceDryRunGraph = ({
         graph,
         copyMaps,
         withAssets: false,
+        classifyStories: true,
     });
 
     return graph;
@@ -2417,6 +2450,7 @@ const buildReferencedAssetsGraph = ({
     sourceAssetFolders,
     schemas,
     copyMaps,
+    classifyStories,
     onScanProgress,
 }: {
     sourceSpace: string;
@@ -2429,6 +2463,7 @@ const buildReferencedAssetsGraph = ({
     sourceAssetFolders: any[];
     schemas: Record<string, any>;
     copyMaps: CopyMaps;
+    classifyStories: boolean;
     onScanProgress?: (progress: {
         scanned: number;
         total: number;
@@ -2436,7 +2471,7 @@ const buildReferencedAssetsGraph = ({
     }) => void;
 }): CopyGraph => {
     const scanResult = scanStoriesReferences({
-        stories: sourceStories.map((item) => item?.story).filter(Boolean),
+        stories: selectPlannedSourceStories(sourceStories, plan),
         schemas,
         options: {
             referencePolicy: "preserve",
@@ -2523,6 +2558,7 @@ const buildReferencedAssetsGraph = ({
         graph,
         copyMaps,
         withAssets: true,
+        classifyStories,
     });
     annotateAssetsWithManifestMaps({
         graph,
@@ -3895,6 +3931,7 @@ export const copyCommand = async (props: CLIOptions) => {
                         sourceAssetFolders,
                         schemas,
                         copyMaps,
+                        classifyStories: true,
                         onScanProgress: logReferenceScanProgress,
                     });
                     Logger.success(
@@ -4147,6 +4184,9 @@ export const copyCommand = async (props: CLIOptions) => {
                     sourceAssetFolders,
                     schemas,
                     copyMaps,
+                    // An asset-only run never rewrites stories, so story
+                    // references stay `unclassified` and never warn.
+                    classifyStories: false,
                     onScanProgress: logReferenceScanProgress,
                 });
                 Logger.success(

--- a/src/cli/commands/copy.ts
+++ b/src/cli/commands/copy.ts
@@ -1,6 +1,9 @@
 import type {
     CopyGraph,
     CopyMaps,
+    CopyRelinkMatch,
+    CopyRelinkPlanItem,
+    CopyRelinkStoryRewrite,
     CopyAssetFolderManifestEntry,
     CopyAssetManifestEntry,
     CopyComponentSchemaRegistry,
@@ -22,6 +25,7 @@ import {
     buildCopyMaps,
     buildCopyPlanGateSummary,
     buildCopyReferenceSelection,
+    buildCopyRelinkPlanSummary,
     classifyStoryReferences,
     countStoryReferenceStatuses,
     createCopyGraph,
@@ -29,10 +33,12 @@ import {
     dedupeManifestFile,
     describeBrokenStoryReferenceTarget,
     formatCopyPlanGate,
+    formatCopyRelinkPlan,
     getDefaultCopyManifestPaths,
     groupBrokenStoryReferences,
     loadManifest,
     normalizeAssetFolderParentId,
+    planCopyRelinkStoryRewrite,
     rewriteCopyReferences,
     scanStoriesReferences,
     summarizeCopyGraph,
@@ -56,6 +62,7 @@ import { askYesNo } from "../helpers.js";
 const COPY_COMMANDS = {
     stories: "stories",
     assets: "assets",
+    relink: "relink",
 };
 
 const COPY_MODES = ["subtree", "children", "self"] as const;
@@ -3881,6 +3888,249 @@ const confirmCopyPlan = async ({ yes }: { yes: boolean }): Promise<boolean> => {
     return confirmed;
 };
 
+type CopyRelinkMatchRecord = {
+    item: CopyPlanItem;
+    sourceStory?: any;
+    targetStory?: any;
+    match: CopyRelinkMatch;
+    rewrite?: CopyRelinkStoryRewrite;
+};
+
+/**
+ * Finds the story each planned item already has in the target space: through a
+ * still-valid ledger mapping first, then by target path. Read-only — adopted
+ * mappings are recorded only once the operator has confirmed the plan.
+ */
+const matchRelinkTargets = async ({
+    plan,
+    sourceStories,
+    copyMaps,
+    targetSpace,
+}: {
+    plan: CopyPlanItem[];
+    sourceStories: any[];
+    copyMaps: CopyMaps;
+    targetSpace: string;
+}): Promise<CopyRelinkMatchRecord[]> => {
+    const sourceStoryByFullSlug = new Map<string, any>(
+        sourceStories
+            .map((item: any) => item?.story)
+            .filter(Boolean)
+            .map((story: any) => [String(story.full_slug ?? ""), story]),
+    );
+    let checked = 0;
+
+    Logger.warning(
+        `Matching ${plan.length} planned item(s) against stories in space '${targetSpace}'.`,
+    );
+
+    const records = await mapWithConcurrency(
+        plan,
+        TARGET_CONFLICT_CHECK_CONCURRENCY,
+        async (item): Promise<CopyRelinkMatchRecord> => {
+            const sourceStory = sourceStoryByFullSlug.get(item.sourceFullSlug);
+            const mappedTargetId = sourceStory
+                ? copyMaps.storyIds.get(Number(sourceStory.id))
+                : undefined;
+            let targetStory: any;
+            let match: CopyRelinkMatch = "missing";
+
+            if (sourceStory && mappedTargetId) {
+                targetStory = await getValidMappedTargetStory({
+                    sourceStory,
+                    targetStoryId: mappedTargetId,
+                    targetFullSlug: item.targetFullSlug,
+                    targetSpace,
+                });
+
+                if (targetStory) {
+                    match = "ledger";
+                }
+            }
+
+            if (!targetStory) {
+                const existingTargetStory =
+                    await managementApi.stories.getStoryBySlug(
+                        item.targetFullSlug,
+                        {
+                            ...apiConfig,
+                            spaceId: targetSpace,
+                        },
+                    );
+
+                if (existingTargetStory?.story?.id) {
+                    targetStory = existingTargetStory.story;
+                    match = "adopted";
+                }
+            }
+
+            checked += 1;
+            if (
+                checked === plan.length ||
+                checked % 25 === 0 ||
+                plan.length <= 25
+            ) {
+                Logger.success(
+                    `Matched ${checked} of ${plan.length} planned item(s).`,
+                );
+            }
+
+            return { item, sourceStory, targetStory, match };
+        },
+    );
+
+    return records;
+};
+
+/**
+ * The write half of `copy relink`: record the adopted mappings, then store the
+ * rewritten content of every story whose references actually changed. Stories
+ * that already point at the right target are never updated.
+ */
+const relinkTargetStories = async ({
+    matches,
+    manifestPaths,
+    sourceSpace,
+    targetSpace,
+}: {
+    matches: CopyRelinkMatchRecord[];
+    manifestPaths: ReturnType<typeof getDefaultCopyManifestPaths>;
+    sourceSpace: string;
+    targetSpace: string;
+}) => {
+    let adopted = 0;
+
+    for (const record of matches) {
+        if (
+            record.match !== "adopted" ||
+            !record.sourceStory?.uuid ||
+            !record.targetStory?.uuid
+        ) {
+            continue;
+        }
+
+        const entry: CopyStoryManifestEntry = {
+            type: "story",
+            source_space_id: sourceSpace,
+            target_space_id: targetSpace,
+            source_id: Number(record.sourceStory.id),
+            target_id: Number(record.targetStory.id),
+            source_uuid: String(record.sourceStory.uuid),
+            target_uuid: String(record.targetStory.uuid),
+            source_full_slug: String(record.sourceStory.full_slug ?? ""),
+            target_full_slug: String(
+                record.targetStory.full_slug ?? record.item.targetFullSlug,
+            ),
+            action: "matched_by_target_key",
+            created_at: new Date().toISOString(),
+        };
+
+        await appendCopyManifestEntry({
+            combinedPath: manifestPaths.combined,
+            resourcePath: manifestPaths.stories,
+            entry,
+        });
+        adopted += 1;
+    }
+
+    if (adopted > 0) {
+        await dedupeManifestFile(manifestPaths.stories);
+        await dedupeManifestFile(manifestPaths.combined);
+        Logger.success(
+            `Recorded ${adopted} adopted target story mapping(s) in the ledger.`,
+        );
+    }
+
+    let updatedStories = 0;
+    let unchangedStories = 0;
+    let rewrittenReferences = 0;
+    let publishedStories = 0;
+    const failures: Array<{ fullSlug: string; message: string }> = [];
+
+    for (const record of matches) {
+        if (!record.rewrite || !record.targetStory) {
+            continue;
+        }
+
+        const targetLabel = String(
+            record.targetStory.full_slug ?? record.item.targetFullSlug,
+        );
+
+        if (!record.rewrite.changed) {
+            unchangedStories += 1;
+            continue;
+        }
+
+        const result = await managementApi.stories.updateStory(
+            { ...record.targetStory, content: record.rewrite.content },
+            String(record.targetStory.id),
+            {
+                publish: false,
+                force_update: true,
+            },
+            {
+                ...apiConfig,
+                spaceId: targetSpace,
+            },
+        );
+
+        try {
+            assertStoryUpdateSucceeded({
+                result,
+                sourceStory: record.sourceStory ?? record.targetStory,
+                targetStoryId: Number(record.targetStory.id),
+                targetSpace,
+                content: record.rewrite.content,
+            });
+        } catch (error) {
+            const message =
+                error instanceof Error ? error.message : String(error);
+            Logger.error(message);
+            failures.push({ fullSlug: targetLabel, message });
+            continue;
+        }
+
+        updatedStories += 1;
+        rewrittenReferences += record.rewrite.rewrittenReferences;
+
+        if (record.targetStory.published === true) {
+            publishedStories += 1;
+        }
+
+        Logger.success(
+            `  ${targetLabel}: ${record.rewrite.rewrittenReferences} reference(s) rewritten.`,
+        );
+    }
+
+    Logger.success(
+        `Relinked ${updatedStories} story/stories in space '${targetSpace}'; rewrote ${rewrittenReferences} reference(s). ${unchangedStories} story/stories already resolved correctly and were left untouched.`,
+    );
+
+    if (publishedStories > 0) {
+        Logger.warning(
+            `${publishedStories} relinked story/stories are published in the target: the repair is in the DRAFT only. Publish them to update live content.`,
+        );
+    }
+
+    if (failures.length > 0) {
+        Logger.error(
+            `${failures.length} story update(s) failed; the rest of the relink still completed. Failed stories:`,
+        );
+
+        for (const failure of failures) {
+            Logger.error(`  - ${failure.fullSlug || "<unknown>"}`);
+        }
+
+        throw new Error(
+            `Relink finished but ${failures.length} story update(s) failed:\n${failures
+                .map((failure) => failure.message)
+                .join("\n")}`,
+        );
+    }
+
+    return { updatedStories, unchangedStories, rewrittenReferences, failures };
+};
+
 export const copyCommand = async (props: CLIOptions) => {
     const { input, flags } = props;
 
@@ -4244,6 +4494,166 @@ export const copyCommand = async (props: CLIOptions) => {
 
                 await writeJsonReport(outputPath, report);
             }
+
+            break;
+        }
+        case COPY_COMMANDS.relink: {
+            const sourceSpace = getCopySpace(
+                flags,
+                ["from", "sourceSpace"],
+                apiConfig.spaceId,
+            );
+            const targetSpace = getCopySpace(
+                flags,
+                ["to", "targetSpace"],
+                apiConfig.spaceId,
+            );
+            const selection = resolveCopySelection(flags);
+            const dryRun = Boolean(flags["dryRun"]);
+            const manifestRoot = readStringFlag(flags, ["manifestRoot"]);
+            const yes = Boolean(flags["yes"]);
+            const destination = readStringFlag(flags, ["destination", "where"]);
+
+            Logger.warning(
+                `Relinking stories in space '${targetSpace}' against their sources in space '${sourceSpace}'.`,
+            );
+            Logger.log(
+                `Source '${selection.source}', mode '${selection.mode}', destination '${destination ?? "root"}'.`,
+            );
+
+            const sourceStories = await getStoriesForSelection(
+                selection,
+                sourceSpace,
+            );
+            const normalizedStories = normalizeStoriesForTree(
+                sourceStories,
+                selection,
+            );
+            const tree = createTree(normalizedStories);
+            const rootsToRelink = prepareTreeForCreate(
+                selectTreeRoots(tree, selection),
+            );
+
+            if (rootsToRelink.length === 0) {
+                Logger.warning("No stories matched the relink selection.");
+                break;
+            }
+
+            const plan = buildCopyPlan(rootsToRelink, destination);
+            const manifestPaths = getDefaultCopyManifestPaths({
+                sourceSpaceId: sourceSpace,
+                targetSpaceId: targetSpace,
+                rootDir: manifestRoot,
+            });
+            const manifestEntries = await loadManifest(manifestPaths.combined);
+            const ledgerPath = path.resolve(manifestPaths.combined);
+            const copyMaps = buildCopyMaps(manifestEntries);
+
+            Logger.warning(
+                manifestEntries.length > 0
+                    ? `Ledger: ${manifestEntries.length} entr${manifestEntries.length === 1 ? "y" : "ies"} loaded from ${ledgerPath}.`
+                    : `Ledger: none at ${ledgerPath}; the mapping is rebuilt from the target space by matching target paths.`,
+            );
+
+            const matches = await matchRelinkTargets({
+                plan,
+                sourceStories,
+                copyMaps,
+                targetSpace,
+            });
+
+            // Every mapping must be complete BEFORE a single story is
+            // rewritten: a reference resolved against a half-built map is
+            // exactly the silent breakage this command exists to repair.
+            for (const match of matches) {
+                if (match.targetStory && match.sourceStory) {
+                    copyMaps.storyIds.set(
+                        Number(match.sourceStory.id),
+                        Number(match.targetStory.id),
+                    );
+                    copyMaps.storyUuids.set(
+                        String(match.sourceStory.uuid),
+                        String(match.targetStory.uuid),
+                    );
+                }
+            }
+
+            const schemas = await buildComponentSchemaRegistry(sourceSpace);
+            const relinkPlan: CopyRelinkPlanItem[] = matches.map((match) => {
+                const rewrite =
+                    match.targetStory && match.item.type === "story"
+                        ? planCopyRelinkStoryRewrite({
+                              content: match.targetStory.content,
+                              maps: copyMaps,
+                              schemas,
+                          })
+                        : undefined;
+
+                match.rewrite = rewrite;
+
+                return {
+                    type: match.item.type,
+                    sourceFullSlug: match.item.sourceFullSlug,
+                    targetFullSlug: match.item.targetFullSlug,
+                    match: match.match,
+                    rewrittenReferences: rewrite?.rewrittenReferences ?? 0,
+                    changed: rewrite?.changed ?? false,
+                };
+            });
+            const graph = buildStoryReferenceDryRunGraph({
+                sourceSpace,
+                targetSpace,
+                selection,
+                destination,
+                plan,
+                sourceStories,
+                schemas,
+                copyMaps,
+                onScanProgress: logReferenceScanProgress,
+            });
+            const referenceCounts = countStoryReferenceStatuses(
+                graph.storyReferences,
+            );
+            const relinkSummary = buildCopyRelinkPlanSummary({
+                sourceSpaceId: sourceSpace,
+                targetSpaceId: targetSpace,
+                plan: relinkPlan,
+                ledger: {
+                    path: ledgerPath,
+                    entries: manifestEntries.length,
+                    ignored: false,
+                },
+                references: {
+                    scanned: true,
+                    total: graph.storyReferences.length,
+                    willRelink: referenceCounts.willRelink,
+                    willBreak: referenceCounts.willBreak,
+                    externalKept: referenceCounts.externalKept,
+                    breaking: groupBrokenStoryReferences(graph.storyReferences),
+                },
+            });
+
+            formatCopyRelinkPlan(relinkSummary).forEach((line) =>
+                Logger.log(line),
+            );
+
+            if (dryRun) {
+                Logger.warning(
+                    "[dry-run] Relink preview only. No Storyblok writes and no ledger entries were made.",
+                );
+                break;
+            }
+
+            if (!(await confirmCopyPlan({ yes }))) {
+                break;
+            }
+
+            await relinkTargetStories({
+                matches,
+                manifestPaths,
+                sourceSpace,
+                targetSpace,
+            });
 
             break;
         }

--- a/src/cli/commands/copy.ts
+++ b/src/cli/commands/copy.ts
@@ -19,9 +19,14 @@ import {
     appendManifestEntry,
     buildCopyAssetsGraph,
     buildCopyMaps,
+    buildCopyReferenceSelection,
+    classifyStoryReferences,
+    countStoryReferenceStatuses,
     createCopyGraph,
     dedupeManifestFile,
+    describeBrokenStoryReferenceTarget,
     getDefaultCopyManifestPaths,
+    groupBrokenStoryReferences,
     loadManifest,
     normalizeAssetFolderParentId,
     rewriteCopyReferences,
@@ -154,8 +159,9 @@ type CopyDryRunReport = {
         assetsMapped: number;
         assetsToCopy: number;
         storyReferences: number;
-        storyReferencesMapped: number;
-        storyReferencesPreserved: number;
+        storyReferencesWillRelink: number;
+        storyReferencesWillBreak: number;
+        storyReferencesExternalKept: number;
         storyReferencesUnresolved: number;
         conflicts: number;
         warnings: number;
@@ -1404,18 +1410,9 @@ const buildCopyDryRunReport = ({
         graph?.assetReferences.filter(
             (reference) => reference.status === "unresolved",
         ).length ?? 0;
-    const storyReferencesMapped =
-        graph?.storyReferences.filter(
-            (reference) => reference.status === "mapped",
-        ).length ?? 0;
-    const storyReferencesPreserved =
-        graph?.storyReferences.filter(
-            (reference) => reference.status === "preserved_external",
-        ).length ?? 0;
-    const storyReferencesUnresolved =
-        graph?.storyReferences.filter(
-            (reference) => reference.status === "unresolved",
-        ).length ?? 0;
+    const storyReferenceCounts = countStoryReferenceStatuses(
+        graph?.storyReferences ?? [],
+    );
     const assetsMapped =
         graph?.assets.filter((asset) => asset.action === "match").length ?? 0;
     const assetsToCopy =
@@ -1458,9 +1455,10 @@ const buildCopyDryRunReport = ({
             assetsMapped,
             assetsToCopy,
             storyReferences: graphSummary?.storyReferences ?? 0,
-            storyReferencesMapped,
-            storyReferencesPreserved,
-            storyReferencesUnresolved,
+            storyReferencesWillRelink: storyReferenceCounts.willRelink,
+            storyReferencesWillBreak: storyReferenceCounts.willBreak,
+            storyReferencesExternalKept: storyReferenceCounts.externalKept,
+            storyReferencesUnresolved: storyReferenceCounts.unresolved,
             conflicts: conflicts.length,
             warnings: warnings.length + (graphSummary?.warnings ?? 0),
             errors: graphSummary?.errors ?? 0,
@@ -2261,15 +2259,27 @@ const annotateReferencesWithManifestMaps = ({
         }
     }
 
-    for (const reference of graph.storyReferences) {
-        if (
-            (reference.referencedStoryId !== undefined &&
-                copyMaps.storyIds.has(reference.referencedStoryId)) ||
-            (reference.referencedStoryUuid !== undefined &&
-                copyMaps.storyUuids.has(reference.referencedStoryUuid))
-        ) {
-            reference.status = "mapped";
-        }
+    // Story references are classified against the copy plan as well as the
+    // ledger: a reference into the selection relinks once phase 2 runs, one
+    // that points outside it dangles. graph.stories already carries the plan.
+    graph.storyReferences = classifyStoryReferences({
+        storyReferences: graph.storyReferences,
+        selection: buildCopyReferenceSelection(graph.stories),
+        copyMaps,
+        sameSpace: graph.sourceSpaceId === graph.targetSpaceId,
+    });
+
+    for (const group of groupBrokenStoryReferences(graph.storyReferences)) {
+        graph.warnings.push({
+            code: "broken_story_reference",
+            message: `Story '${group.sourceStoryFullSlug}' references ${group.references.length} story/stories outside this copy that are not in the ledger; the copied content will point at nothing.`,
+            path: group.references
+                .map((reference) => reference.path)
+                .join(", "),
+            sourceValue: group.references.map(
+                describeBrokenStoryReferenceTarget,
+            ),
+        });
     }
 };
 
@@ -3614,8 +3624,26 @@ const logDryRunCopyPlan = async ({ report }: { report: CopyDryRunReport }) => {
         }
 
         Logger.warning(
-            `[dry-run] Story refs: ${report.summary.storyReferencesMapped} mapped, ${report.summary.storyReferencesPreserved} preserved, ${report.summary.storyReferencesUnresolved} unresolved.`,
+            `[dry-run] Story refs: ${report.summary.storyReferencesWillRelink} will relink, ${report.summary.storyReferencesWillBreak} will break, ${report.summary.storyReferencesExternalKept} external kept, ${report.summary.storyReferencesUnresolved} unresolved.`,
         );
+
+        if (report.summary.storyReferencesWillBreak > 0) {
+            Logger.error(
+                `[dry-run] ${report.summary.storyReferencesWillBreak} story reference(s) WILL BREAK: they point at stories outside this copy and are not in the ledger, so the copied content will point at nothing.`,
+            );
+
+            for (const group of groupBrokenStoryReferences(
+                report.graph.storyReferences,
+            )) {
+                Logger.error(`[dry-run]   ${group.sourceStoryFullSlug}`);
+
+                for (const reference of group.references) {
+                    Logger.error(
+                        `[dry-run]     ${reference.path} -> ${describeBrokenStoryReferenceTarget(reference)}`,
+                    );
+                }
+            }
+        }
 
         for (const folder of report.graph.assetFolders) {
             Logger.warning(

--- a/src/cli/commands/copy.ts
+++ b/src/cli/commands/copy.ts
@@ -3,6 +3,7 @@ import type {
     CopyMaps,
     CopyRelinkMatch,
     CopyRelinkPlanItem,
+    CopyRelinkStoryMapping,
     CopyRelinkStoryRewrite,
     CopyAssetFolderManifestEntry,
     CopyAssetManifestEntry,
@@ -25,6 +26,8 @@ import {
     buildCopyMaps,
     buildCopyPlanGateSummary,
     buildCopyReferenceSelection,
+    buildCopyRelinkClassificationMaps,
+    buildCopyRelinkMaps,
     buildCopyRelinkPlanSummary,
     classifyStoryReferences,
     countStoryReferenceStatuses,
@@ -41,6 +44,7 @@ import {
     planCopyRelinkStoryRewrite,
     rewriteCopyReferences,
     scanStoriesReferences,
+    selectRelinkLedgerStoryMappings,
     summarizeCopyGraph,
 } from "../../api/copy/index.js";
 import {
@@ -2292,6 +2296,7 @@ const annotateReferencesWithManifestMaps = ({
     copyMaps,
     withAssets,
     classifyStories,
+    unmappedSourceFullSlugs,
 }: {
     graph: CopyGraph;
     copyMaps: CopyMaps;
@@ -2302,6 +2307,12 @@ const annotateReferencesWithManifestMaps = ({
      * neutral `unclassified` status in place.
      */
     classifyStories: boolean;
+    /**
+     * Planned stories that will have no mapping when content is rewritten.
+     * `copy stories` creates them all and passes nothing; `copy relink` passes
+     * the stories missing from the target, whose references really do break.
+     */
+    unmappedSourceFullSlugs?: ReadonlySet<string>;
 }) => {
     for (const reference of graph.assetReferences) {
         if (hasMappedAssetReference({ ...reference, copyMaps })) {
@@ -2323,7 +2334,9 @@ const annotateReferencesWithManifestMaps = ({
     // that points outside it dangles. graph.stories already carries the plan.
     graph.storyReferences = classifyStoryReferences({
         storyReferences: graph.storyReferences,
-        selection: buildCopyReferenceSelection(graph.stories),
+        selection: buildCopyReferenceSelection(graph.stories, {
+            excludeSourceFullSlugs: unmappedSourceFullSlugs,
+        }),
         copyMaps,
         sameSpace: graph.sourceSpaceId === graph.targetSpaceId,
     });
@@ -2417,6 +2430,7 @@ const buildStoryReferenceDryRunGraph = ({
     sourceStories,
     schemas,
     copyMaps,
+    unmappedSourceFullSlugs,
     onScanProgress,
 }: {
     sourceSpace: string;
@@ -2427,6 +2441,8 @@ const buildStoryReferenceDryRunGraph = ({
     sourceStories: any[];
     schemas: Record<string, any>;
     copyMaps: CopyMaps;
+    /** Planned stories this run will not map; see the annotator. */
+    unmappedSourceFullSlugs?: ReadonlySet<string>;
     onScanProgress?: (progress: {
         scanned: number;
         total: number;
@@ -2482,6 +2498,7 @@ const buildStoryReferenceDryRunGraph = ({
         copyMaps,
         withAssets: false,
         classifyStories: true,
+        unmappedSourceFullSlugs,
     });
 
     return graph;
@@ -3983,6 +4000,70 @@ const matchRelinkTargets = async ({
 };
 
 /**
+ * Keeps only the out-of-selection ledger mappings whose target story is still
+ * there. Relink writes THROUGH these mappings, so an unchecked one turns a
+ * broken reference into a reference to a story that no longer exists — the one
+ * outcome worse than leaving the break alone. Only mappings the target content
+ * actually mentions are checked, so the cost is bounded by the damage.
+ */
+const validateRelinkLedgerMappings = async ({
+    mappings,
+    targetSpace,
+}: {
+    mappings: CopyRelinkStoryMapping[];
+    targetSpace: string;
+}): Promise<{
+    valid: CopyRelinkStoryMapping[];
+    stale: CopyRelinkStoryMapping[];
+}> => {
+    if (mappings.length === 0) {
+        return { valid: [], stale: [] };
+    }
+
+    Logger.warning(
+        `Validating ${mappings.length} ledger mapping(s) referenced by the target content but outside this selection.`,
+    );
+
+    const checked = await mapWithConcurrency(
+        mappings,
+        TARGET_CONFLICT_CHECK_CONCURRENCY,
+        async (mapping) => {
+            const targetStory = await managementApi.stories.getStoryById(
+                String(mapping.targetId),
+                {
+                    ...apiConfig,
+                    spaceId: targetSpace,
+                },
+            );
+            const foundUuid = targetStory?.story?.uuid;
+
+            if (
+                targetStory?.story?.id &&
+                (!mapping.targetUuid ||
+                    String(foundUuid) === mapping.targetUuid)
+            ) {
+                return { mapping, valid: true };
+            }
+
+            Logger.warning(
+                `Ignoring stale story manifest mapping for '${mapping.sourceFullSlug || `#${mapping.sourceId}`}' because target story '${mapping.targetId}' was not found in space '${targetSpace}'. References to it are left as they are.`,
+            );
+
+            return { mapping, valid: false };
+        },
+    );
+
+    return {
+        valid: checked
+            .filter((result) => result.valid)
+            .map((result) => result.mapping),
+        stale: checked
+            .filter((result) => !result.valid)
+            .map((result) => result.mapping),
+    };
+};
+
+/**
  * The write half of `copy relink`: record the adopted mappings, then store the
  * rewritten content of every story whose references actually changed. Stories
  * that already point at the right target are never updated.
@@ -4547,7 +4628,7 @@ export const copyCommand = async (props: CLIOptions) => {
             });
             const manifestEntries = await loadManifest(manifestPaths.combined);
             const ledgerPath = path.resolve(manifestPaths.combined);
-            const copyMaps = buildCopyMaps(manifestEntries);
+            const ledgerMaps = buildCopyMaps(manifestEntries);
 
             Logger.warning(
                 manifestEntries.length > 0
@@ -4558,25 +4639,83 @@ export const copyCommand = async (props: CLIOptions) => {
             const matches = await matchRelinkTargets({
                 plan,
                 sourceStories,
-                copyMaps,
+                copyMaps: ledgerMaps,
                 targetSpace,
             });
 
             // Every mapping must be complete BEFORE a single story is
             // rewritten: a reference resolved against a half-built map is
             // exactly the silent breakage this command exists to repair.
-            for (const match of matches) {
-                if (match.targetStory && match.sourceStory) {
-                    copyMaps.storyIds.set(
-                        Number(match.sourceStory.id),
-                        Number(match.targetStory.id),
-                    );
-                    copyMaps.storyUuids.set(
-                        String(match.sourceStory.uuid),
-                        String(match.targetStory.uuid),
-                    );
-                }
-            }
+            //
+            // It must also contain nothing but mappings this run VERIFIED.
+            // The ledger is a record of what was true when it was written, and
+            // relinking through a mapping whose target has since been deleted
+            // would replace a broken reference with a dangling one.
+            const matchedStoryMappings: CopyRelinkStoryMapping[] = matches
+                .filter(
+                    (match) =>
+                        match.sourceStory?.uuid && match.targetStory?.uuid,
+                )
+                .map((match) => ({
+                    sourceId: Number(match.sourceStory.id),
+                    sourceUuid: String(match.sourceStory.uuid),
+                    targetId: Number(match.targetStory.id),
+                    targetUuid: String(match.targetStory.uuid),
+                    sourceFullSlug: String(
+                        match.sourceStory.full_slug ??
+                            match.item.sourceFullSlug,
+                    ),
+                    targetFullSlug: String(
+                        match.targetStory.full_slug ??
+                            match.item.targetFullSlug,
+                    ),
+                }));
+            // Stories outside the selection are still repairable — relinking
+            // `pages` alone must fix its links into `shared` — but only once
+            // their mapping is checked against the target the same way.
+            const ledgerStoryMappings = await validateRelinkLedgerMappings({
+                mappings: selectRelinkLedgerStoryMappings({
+                    entries: manifestEntries,
+                    plannedSourceIds: new Set(
+                        matches
+                            .map((match) => Number(match.sourceStory?.id))
+                            .filter((sourceId) => Number.isFinite(sourceId)),
+                    ),
+                    targetContents: matches.map(
+                        (match) => match.targetStory?.content,
+                    ),
+                }),
+                targetSpace,
+            });
+            const validatedStoryMappings = [
+                ...matchedStoryMappings,
+                ...ledgerStoryMappings.valid,
+            ];
+            const copyMaps = buildCopyRelinkMaps({
+                ledgerMaps,
+                storyMappings: validatedStoryMappings,
+            });
+            // The PLAN counts read against the ledger as corrected by this run:
+            // out-of-selection mappings still count as covered, but everything
+            // proven stale is gone, so the counts cannot promise what the
+            // rewrite above will refuse to do.
+            const classificationMaps = buildCopyRelinkClassificationMaps({
+                ledgerMaps,
+                storyMappings: validatedStoryMappings,
+                staleStoryKeys: [
+                    ...matches
+                        .filter(
+                            (match) =>
+                                match.match === "missing" &&
+                                match.sourceStory?.uuid,
+                        )
+                        .map((match) => ({
+                            sourceId: Number(match.sourceStory.id),
+                            sourceUuid: String(match.sourceStory.uuid),
+                        })),
+                    ...ledgerStoryMappings.stale,
+                ],
+            });
 
             const schemas = await buildComponentSchemaRegistry(sourceSpace);
             const relinkPlan: CopyRelinkPlanItem[] = matches.map((match) => {
@@ -4608,7 +4747,14 @@ export const copyCommand = async (props: CLIOptions) => {
                 plan,
                 sourceStories,
                 schemas,
-                copyMaps,
+                copyMaps: classificationMaps,
+                // Relink never creates a story, so a reference into one that is
+                // missing from the target breaks; it cannot relink.
+                unmappedSourceFullSlugs: new Set(
+                    matches
+                        .filter((match) => match.match === "missing")
+                        .map((match) => match.item.sourceFullSlug),
+                ),
                 onScanProgress: logReferenceScanProgress,
             });
             const referenceCounts = countStoryReferenceStatuses(

--- a/src/cli/commands/copy.ts
+++ b/src/cli/commands/copy.ts
@@ -994,14 +994,21 @@ const buildCopyPlan = (
     return plan;
 };
 
+type CopyTargetConflictCheck = {
+    /** Planned paths that already hold a story or folder in the target. */
+    conflicts: CopyPlanItem[];
+    /** Id of the story occupying each of those paths, keyed by target path. */
+    existingTargetStoryIdByFullSlug: Map<string, number>;
+};
+
 const findTargetConflicts = async (
     plan: CopyPlanItem[],
     targetSpace: string,
-): Promise<CopyPlanItem[]> => {
+): Promise<CopyTargetConflictCheck> => {
     let checked = 0;
 
     if (plan.length === 0) {
-        return [];
+        return { conflicts: [], existingTargetStoryIdByFullSlug: new Map() };
     }
 
     Logger.warning(
@@ -1031,19 +1038,48 @@ const findTargetConflicts = async (
                 );
             }
 
-            return existingStory ? item : null;
+            if (!existingStory) {
+                return null;
+            }
+
+            const existingStoryId = existingStory?.story?.id;
+
+            return {
+                item,
+                existingTargetStoryId:
+                    existingStoryId === undefined
+                        ? undefined
+                        : Number(existingStoryId),
+            };
         },
     );
 
-    const conflicts = results.filter(
-        (item): item is CopyPlanItem => item !== null,
+    const found = results.filter(
+        (
+            result,
+        ): result is {
+            item: CopyPlanItem;
+            existingTargetStoryId: number | undefined;
+        } => result !== null,
+    );
+    const conflicts = found.map((result) => result.item);
+    const existingTargetStoryIdByFullSlug = new Map<string, number>(
+        found
+            .filter((result) => result.existingTargetStoryId !== undefined)
+            .map(
+                (result) =>
+                    [
+                        result.item.targetFullSlug,
+                        result.existingTargetStoryId as number,
+                    ] as const,
+            ),
     );
 
     Logger.success(
         `Target conflict check complete. Found ${conflicts.length} existing target path(s).`,
     );
 
-    return conflicts;
+    return { conflicts, existingTargetStoryIdByFullSlug };
 };
 
 const withConflictFlags = (
@@ -4015,7 +4051,10 @@ export const copyCommand = async (props: CLIOptions) => {
             }
 
             if (dryRun) {
-                const conflicts = await findTargetConflicts(plan, targetSpace);
+                const { conflicts } = await findTargetConflicts(
+                    plan,
+                    targetSpace,
+                );
                 Logger.warning(
                     "Checking source components against the target space schema.",
                 );
@@ -4063,7 +4102,8 @@ export const copyCommand = async (props: CLIOptions) => {
                 break;
             }
 
-            const conflicts = await findTargetConflicts(plan, targetSpace);
+            const { existingTargetStoryIdByFullSlug } =
+                await findTargetConflicts(plan, targetSpace);
             const sourceStoryByFullSlug = new Map(
                 sourceStories
                     .map((item: any) => item?.story)
@@ -4076,17 +4116,30 @@ export const copyCommand = async (props: CLIOptions) => {
             const planGate = buildCopyPlanGateSummary({
                 sourceSpaceId: sourceSpace,
                 targetSpaceId: targetSpace,
-                plan: plan.map((item) => ({
-                    type: item.type,
-                    sourceId: sourceStoryByFullSlug.get(item.sourceFullSlug)
-                        ?.id,
-                    sourceFullSlug: item.sourceFullSlug,
-                    targetFullSlug: item.targetFullSlug,
-                })),
-                conflictTargetFullSlugs: conflicts.map(
-                    (conflict) => conflict.targetFullSlug,
-                ),
-                copyMaps,
+                plan: plan.map((item) => {
+                    const sourceId = sourceStoryByFullSlug.get(
+                        item.sourceFullSlug,
+                    )?.id;
+
+                    return {
+                        type: item.type,
+                        sourceFullSlug: item.sourceFullSlug,
+                        targetFullSlug: item.targetFullSlug,
+                        // A ledger mapping only survives the gate if the story
+                        // it points at is the one living at the planned target
+                        // path — the same rule `getValidMappedTargetStory`
+                        // applies per story once writing starts, answered here
+                        // from the target check the gate already ran.
+                        ledgerTargetStoryId:
+                            sourceId === undefined
+                                ? undefined
+                                : copyMaps.storyIds.get(Number(sourceId)),
+                        existingTargetStoryId:
+                            existingTargetStoryIdByFullSlug.get(
+                                item.targetFullSlug,
+                            ),
+                    };
+                }),
                 ledger,
                 graph: dryRunGraph,
                 withAssets,

--- a/src/cli/commands/copy.ts
+++ b/src/cli/commands/copy.ts
@@ -17,14 +17,18 @@ import path from "path";
 
 import {
     appendManifestEntry,
+    archiveCopyManifests,
     buildCopyAssetsGraph,
     buildCopyMaps,
+    buildCopyPlanGateSummary,
     buildCopyReferenceSelection,
     classifyStoryReferences,
     countStoryReferenceStatuses,
     createCopyGraph,
+    createEmptyCopyMaps,
     dedupeManifestFile,
     describeBrokenStoryReferenceTarget,
+    formatCopyPlanGate,
     getDefaultCopyManifestPaths,
     groupBrokenStoryReferences,
     loadManifest,
@@ -47,6 +51,7 @@ import { mapWithConcurrency } from "../../utils/async-utils.js";
 import Logger from "../../utils/logger.js";
 import { getFileName } from "../../utils/string-utils.js";
 import { apiConfig } from "../api-config.js";
+import { askYesNo } from "../helpers.js";
 
 const COPY_COMMANDS = {
     stories: "stories",
@@ -3812,6 +3817,34 @@ const logDryRunCopyAssetsPlan = async ({
     );
 };
 
+/**
+ * The single gate between planning and the first API write. `--yes` passes
+ * it (the plan still prints); without a terminal there is nobody to ask, so
+ * the run refuses rather than guessing.
+ */
+const confirmCopyPlan = async ({ yes }: { yes: boolean }): Promise<boolean> => {
+    if (yes) {
+        Logger.log("Continuing without confirmation (--yes).");
+        return true;
+    }
+
+    if (!process.stdin.isTTY) {
+        Logger.error(
+            "Refusing to write without confirmation: no interactive terminal. Re-run with --yes to continue, or --dry-run to only plan.",
+        );
+        process.exitCode = 1;
+        return false;
+    }
+
+    const confirmed = await askYesNo("Continue? [y/N]");
+
+    if (!confirmed) {
+        Logger.warning("Copy aborted before any write.");
+    }
+
+    return confirmed;
+};
+
 export const copyCommand = async (props: CLIOptions) => {
     const { input, flags } = props;
 
@@ -3836,6 +3869,8 @@ export const copyCommand = async (props: CLIOptions) => {
             const withAssets = Boolean(
                 flags["withAssets"] ?? flags["with-assets"],
             );
+            const yes = Boolean(flags["yes"]);
+            const fresh = Boolean(flags["fresh"]);
             const publication = await resolveCopyPublicationOptions({
                 flags,
                 targetSpace,
@@ -3879,13 +3914,32 @@ export const copyCommand = async (props: CLIOptions) => {
                 rootDir: manifestRoot,
             });
             const manifestEntries = await loadManifest(manifestPaths.combined);
-            const copyMaps = buildCopyMaps(manifestEntries);
+            const ledgerPath = path.resolve(manifestPaths.combined);
+            // --fresh: the ledger on disk is read only to be announced; the
+            // run plans and classifies against an empty one.
+            const copyMaps = fresh
+                ? createEmptyCopyMaps()
+                : buildCopyMaps(manifestEntries);
+            const ledger = {
+                path: ledgerPath,
+                entries: manifestEntries.length,
+                ignored: fresh,
+            };
+            Logger.warning(
+                fresh
+                    ? `Ledger: ${manifestEntries.length} entr${manifestEntries.length === 1 ? "y" : "ies"} at ${ledgerPath} IGNORED (--fresh).`
+                    : manifestEntries.length > 0
+                      ? `Ledger: ${manifestEntries.length} entr${manifestEntries.length === 1 ? "y" : "ies"} loaded from ${ledgerPath} (resuming; use --fresh to ignore).`
+                      : `Ledger: none at ${ledgerPath} (starting empty).`,
+            );
             let dryRunGraph: CopyGraph | undefined;
             let withAssetsGraph: CopyGraph | undefined;
             let sourceAssets: any[] = [];
             let sourceAssetFolders: any[] = [];
 
-            if (dryRun || withAssets) {
+            // The reference scan runs in apply mode too: the plan gate needs
+            // will-relink / will-break counts before the first write.
+            {
                 const schemasPromise =
                     buildComponentSchemaRegistry(sourceSpace);
 
@@ -3938,7 +3992,7 @@ export const copyCommand = async (props: CLIOptions) => {
                         `Reference planning complete. Found ${withAssetsGraph.assets.length} referenced asset(s), ${withAssetsGraph.assetFolders.length} asset folder(s), ${withAssetsGraph.assetReferences.length} asset reference occurrence(s), and ${withAssetsGraph.storyReferences.length} story reference occurrence(s).`,
                     );
                     dryRunGraph = withAssetsGraph;
-                } else if (dryRun) {
+                } else {
                     const schemas = await schemasPromise;
                     Logger.warning(
                         `Scanning ${countStoryItems(sourceStories)} stories for copy references.`,
@@ -4007,6 +4061,51 @@ export const copyCommand = async (props: CLIOptions) => {
                 }
 
                 break;
+            }
+
+            const conflicts = await findTargetConflicts(plan, targetSpace);
+            const sourceStoryByFullSlug = new Map(
+                sourceStories
+                    .map((item: any) => item?.story)
+                    .filter(Boolean)
+                    .map(
+                        (story: any) =>
+                            [String(story.full_slug ?? ""), story] as const,
+                    ),
+            );
+            const planGate = buildCopyPlanGateSummary({
+                sourceSpaceId: sourceSpace,
+                targetSpaceId: targetSpace,
+                plan: plan.map((item) => ({
+                    type: item.type,
+                    sourceId: sourceStoryByFullSlug.get(item.sourceFullSlug)
+                        ?.id,
+                    sourceFullSlug: item.sourceFullSlug,
+                    targetFullSlug: item.targetFullSlug,
+                })),
+                conflictTargetFullSlugs: conflicts.map(
+                    (conflict) => conflict.targetFullSlug,
+                ),
+                copyMaps,
+                ledger,
+                graph: dryRunGraph,
+                withAssets,
+            });
+
+            formatCopyPlanGate(planGate).forEach((line) => Logger.log(line));
+
+            if (!(await confirmCopyPlan({ yes }))) {
+                break;
+            }
+
+            if (fresh) {
+                const archived = await archiveCopyManifests(manifestPaths);
+
+                Logger.warning(
+                    archived.length > 0
+                        ? `--fresh: moved ${archived.length} ledger file(s) aside so this run starts empty: ${archived.join(", ")}`
+                        : "--fresh: no ledger files to move aside; starting empty.",
+                );
             }
 
             let assetCopyReport: CopyAssetsApplyReport | undefined;

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -47,3 +47,21 @@ export const askForConfirmation = async (
         rl.close();
     }
 };
+
+/**
+ * One yes/no question on the terminal. Resolves true only for an explicit
+ * `y`/`yes`; an empty answer or anything else is a no.
+ */
+export const askYesNo = async (message: string): Promise<boolean> => {
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+
+    try {
+        const answer = await rl.question(`${message} `);
+        return ["y", "yes"].includes(answer.trim().toLowerCase());
+    } finally {
+        rl.close();
+    }
+};


### PR DESCRIPTION
Phase 3 of the copy-stability run. Stacked on #397 (needs the plan gate) and #396 (needs the classifier); the diff carries their commits until they merge, so review `972216c` alone for this phase.

## Why

A story copied before the stories it references keeps source-space ids and uuids in its target content **permanently**. Copying the referenced stories in a later run does not repair content that was already written (live probe, scenario D), so the only remedy today is re-running the whole copy — which rewrites every story's content to fix a handful of reference values.

## What shipped

`sb-mig copy relink --from <src> --to <tgt> --source <slug> [--destination <slug>] [--mode <mode>] [--dryRun] [--yes] [--manifestRoot <dir>]`

Phase 2 alone, over stories that already exist in the target:

1. Take the same `--source`, `--destination` and `--mode` as the copy being repaired, so the planned target paths line up.
2. Complete the mapping: still-valid ledger mappings first, then the target's own paths. Adopted stories are recorded as `matched_by_target_key`.
3. Rewrite each target story's **own** content through `rewriteCopyReferences`. No stories are created and nothing is copied from the source — only reference values change.

The mapping is completed for **every** planned item before the first story is rewritten: a reference resolved against a half-built map is exactly the silent breakage this command exists to repair.

A story whose references already resolve is not written at all. The decision compares values rather than counting rewrite records, so a reference that maps to itself never triggers a gratuitous update.

The plan gate from MAR-2669 applies, and its PLAN block states the exact rewrite rather than an estimate — by the time it prints, the target content has already been read and rewritten in memory:

```
PLAN
  9 planned items (3 folders) in space 294800411038803 (5 mapped by ledger, 4 adopted by target path, 0 missing from target)
    4 target stories will be added to the ledger as matched_by_target_key.
  ledger: 5 entries loaded from /…/manifest.jsonl (resuming; use --fresh to ignore)
  references: 17 will relink, 1 leave your selection and WILL BREAK
    WILL BREAK, by story:
      sb-mig-probe/pages/page-four
        content.ref_link.id -> 5b7207f1-a15d-4da7-895f-f13a36e53108
  rewrite: 9 references in 1 story; 5 already correct and left untouched
  content: only reference values change; nothing is copied from the source
```

Updates are drafts, so relinked stories that are published in the target are named as such and need publishing afterwards.

## Live verification (built binary, probe spaces)

| Step | Result |
| --- | --- |
| Copy `pages` without `shared`, fresh ledger | fixture drops to **3/11** resolvable references (the reported symptom) |
| One `copy relink` run over the whole subtree | **11/11** — every shape repaired, including all four `__i18n__de` variants and the bare uuid in a text field |
| Second `copy relink` run | 0 rewrites, 0 updates, 6 stories already correct |
| `--manifestRoot` pointing at nothing | all 9 items adopted from the target; `--dryRun` created no files at all |

## Gate

- `npm run test:unit`: 60 files, **622/622** (+12: 7 pure relink tests, 5 CLI tests — repair with an empty ledger, already-correct story untouched, gate refusal before any ledger write, `--dryRun` writes nothing, planned story missing from the target).
- `npm run lint`, `npm run typecheck`, `npm run build` clean.
- Built-binary routing smoke: `node dist/cli/index.js copy relink …` routes and reaches the API (401 on dummy space ids); `copy --help` documents the command and still contains no question marks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)