### PR TITLE
fix(ci): run semantic-release once so a failed npm publish fails the job

### DIFF
--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -44,18 +44,18 @@ jobs:
         run: |
           npm run test
 
-      - name: Retry Release
+      # semantic-release is NOT idempotent: it tags, commits the changelog and
+      # publishes the GitHub release before npm. A retry after a partial failure
+      # sees the tag and reports "nothing to release" (exit 0), turning a failed npm
+      # publish into a green job. Run it exactly once and let a failure fail.
+      # NPM_TOKEN must be an npm automation token or a granular token with
+      # "Bypass 2FA": semantic-release cannot answer a one-time-password prompt.
+      - name: Release
         if: matrix.node-version == '24.x'
-        uses: nick-fields/retry@v4
         env:
           NO_HUSKY: 1
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_OPTIONS: "--max_old_space_size=8192"
-        with:
-          command: |
-            npx semantic-release
-          max_attempts: 3
-          retry_wait_seconds: 300
-          timeout_minutes: 10
+        run: npx semantic-release

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -263,19 +263,20 @@ jobs:
           name: dist
           path: .
 
-      - name: Retry Release
-        uses: nick-fields/retry@v4
+      # semantic-release is NOT idempotent: it tags, commits the changelog and
+      # publishes the GitHub release before npm. A retry after a partial failure
+      # sees the tag and reports "nothing to release" (exit 0), turning a failed npm
+      # publish into a green job. Run it exactly once and let a failure fail.
+      # NPM_TOKEN must be an npm automation token or a granular token with
+      # "Bypass 2FA": semantic-release cannot answer a one-time-password prompt.
+      - name: Release
         env:
           NO_HUSKY: 1
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_OPTIONS: "--max_old_space_size=8192"
-        with:
-          command: npx semantic-release
-          max_attempts: 3
-          retry_wait_seconds: 300
-          timeout_minutes: 10
+        run: npx semantic-release
 
   # ============================================================================
   # Summary Job


### PR DESCRIPTION
## Why

Release Beta run 34350729587 (2026-09-09) produced a half-release: tag `v6.5.0-beta.3`, the changelog commit and the GitHub release exist, but the npm publish failed with `EOTP` (the token required a one-time password) — and the job still reported **success**. Both release workflows wrap `npx semantic-release` in `nick-fields/retry@v4` with three attempts. semantic-release is not idempotent across attempts: after a partial failure the retry sees the existing tag, decides there is nothing to release, and exits 0.

## Change

- `release-beta.yaml`, `release-stable.yaml`: replace the retry step with a single `run: npx semantic-release`. A failure now fails the job.
- Comment next to the step stating the credential requirement: `NPM_TOKEN` must be an npm automation token or a granular token with "Bypass 2FA".

No change to versioning or plugins. Merging this is itself a releasable `fix` commit, so `beta` cuts `6.5.0-beta.4` and publishes it to npm; `6.5.0-beta.3` stays a git/GitHub-only tag.

Refs MAR-2890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)